### PR TITLE
Exposing JSonSerializerSettings

### DIFF
--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_loaded_by_id.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_loaded_by_id.cs
@@ -30,6 +30,7 @@
             TestSagaData sagaData;
             using (var completeSession = await configuration.SynchronizedStorage.OpenSession(intentionallySharedContext))
             {
+                SetActiveSagaInstance(intentionallySharedContext, new TestSaga(), new TestSagaData());
                 sagaData = await persister.Get<TestSagaData>(generatedSagaId, completeSession, intentionallySharedContext);
                 SetActiveSagaInstance(intentionallySharedContext, new TestSaga(), sagaData);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -28,6 +28,7 @@
             SagaWithCorrelationPropertyData sagaData;
             using (var completeSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
+                SetActiveSagaInstance(intentionallySharedContext, new SagaWithCorrelationProperty(), new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData });
                 sagaData = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, completeSession, intentionallySharedContext);
                 SetActiveSagaInstance(intentionallySharedContext, new SagaWithCorrelationProperty(), sagaData);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
@@ -35,6 +35,7 @@
             var completingContextBag = configuration.GetContextBagForSagaStorage();
             using (var completingSession = await configuration.SynchronizedStorage.OpenSession(completingContextBag))
             {
+                SetActiveSagaInstance(completingContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData(), typeof(CustomFinder));
                 var saga = await persister.Get<SagaWithoutCorrelationPropertyData>(generatedSagaId, completingSession, completingContextBag);
                 SetActiveSagaInstance(completingContextBag, new SagaWithoutCorrelationProperty(), saga, typeof(CustomFinder));
 
@@ -45,7 +46,7 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData }, typeof(CustomFinder));
+                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData { Id = generatedSagaId, FoundByFinderProperty = propertyData }, typeof(CustomFinder));
 
                 var result = await persister.Get<SagaWithoutCorrelationPropertyData>(generatedSagaId, readSession, readContextBag);
                 Assert.That(result, Is.Null);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
@@ -33,7 +33,9 @@ namespace NServiceBus.Persistence.ComponentTests
             {
                 var winningContext = configuration.GetContextBagForSagaStorage();
                 var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
+                SetActiveSagaInstance(winningContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
                 var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
+                SetActiveSagaInstance(winningContext, new TestSaga(), record);
 
                 startSecondTaskSync.SetResult(true);
                 await firstTaskCanCompleteSync.Task;
@@ -51,7 +53,9 @@ namespace NServiceBus.Persistence.ComponentTests
 
                 var losingSaveContext = configuration.GetContextBagForSagaStorage();
                 var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingSaveContext);
+                SetActiveSagaInstance(losingSaveContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
                 var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);
+                SetActiveSagaInstance(losingSaveContext, new TestSaga(), staleRecord);
 
                 firstTaskCanCompleteSync.SetResult(true);
                 await firstTask;

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs
@@ -27,11 +27,15 @@
 
             var winningContext = configuration.GetContextBagForSagaStorage();
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
+            SetActiveSagaInstance(winningContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
             var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
+            SetActiveSagaInstance(winningContext, new TestSaga(), record);
 
             var losingContext = configuration.GetContextBagForSagaStorage();
             var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
+            SetActiveSagaInstance(losingContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
+            SetActiveSagaInstance(losingContext, new TestSaga(), staleRecord);
 
             record.DateTimeProperty = DateTime.Now;
             await persister.Update(record, winningSaveSession, winningContext);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -45,9 +45,11 @@ namespace NServiceBus.Persistence.ComponentTests
                     var enlistedContextBag = configuration.GetContextBagForSagaStorage();
                     var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
 
+                    SetActiveSagaInstance(unenlistedContextBag, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
                     var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
                     SetActiveSagaInstance(unenlistedContextBag, new TestSaga(), unenlistedRecord);
 
+                    SetActiveSagaInstance(enlistedContextBag, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
                     var enlistedRecord = await persister.Get<TestSagaData>("Id", generatedSagaId, enlistedSession, enlistedContextBag);
                     SetActiveSagaInstance(enlistedContextBag, new TestSaga(), enlistedRecord);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_complex_types.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_complex_types.cs
@@ -29,6 +29,7 @@
             var readingContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
+                SetActiveSagaInstance(readingContextBag, new SagaWithComplexType(), sagaData);
                 var retrieved = await persister.Get<SagaWithComplexTypeEntity>(generatedSagaId, session, readingContextBag);
                 SetActiveSagaInstance(readingContextBag, new SagaWithComplexType(), retrieved);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_no_defined_unique_property.cs
@@ -30,10 +30,7 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData
-                {
-                    FoundByFinderProperty = propertyData
-                }, typeof(CustomFinder));
+                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData }, typeof(CustomFinder));
 
                 var result = await persister.Get<SagaWithoutCorrelationPropertyData>(generateSagaId, readSession, readContextBag);
                 Assert.AreEqual(sagaData.FoundByFinderProperty, result.FoundByFinderProperty);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
@@ -38,7 +38,10 @@ namespace NServiceBus.Persistence.ComponentTests
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
+                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), saga1, typeof(CustomFinder));
                 var saga1Result = await persister.Get<SagaWithoutCorrelationPropertyData>(saga1.Id, readSession, readContextBag);
+
+                SetActiveSagaInstance(readContextBag, new AnotherSagaWithoutCorrelationProperty(), saga2, typeof(AnotherCustomFinder));
                 var saga2Result = await persister.Get<AnotherSagaWithoutCorrelationPropertyData>(saga2.Id, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.FoundByFinderProperty, saga1Result.FoundByFinderProperty);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
@@ -36,7 +36,10 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
+                SetActiveSagaInstance(readContextBag, new SagaWithCorrelationProperty(), saga1);
                 var saga1Result = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), saga1.CorrelatedProperty, readSession, readContextBag);
+
+                SetActiveSagaInstance(readContextBag, new AnotherSagaWithCorrelatedProperty(), saga2);
                 var saga2Result = await persister.Get<AnotherSagaWithCorrelatedPropertyData>(nameof(AnotherSagaWithCorrelatedPropertyData.CorrelatedProperty), saga2.CorrelatedProperty, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.CorrelatedProperty, saga1Result.CorrelatedProperty);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_the_same_saga_twice.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_the_same_saga_twice.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Persistence.ComponentTests
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new TestSaga(), new TestSagaData());
+                SetActiveSagaInstance(readContextBag, new TestSaga(), saga);
 
                 returnedSaga1 = await persister.Get<TestSagaData>(saga.Id, readSession, readContextBag);
 
@@ -38,7 +38,7 @@ namespace NServiceBus.Persistence.ComponentTests
             readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new TestSaga(), new TestSagaData());
+                SetActiveSagaInstance(readContextBag, new TestSaga(), saga);
 
                 returnedSaga2 = await persister.Get<TestSagaData>("Id", saga.Id, readSession, readContextBag);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_saga_not_found_return_default.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_saga_not_found_return_default.cs
@@ -14,6 +14,8 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
+                SetActiveSagaInstance(readContextBag, new SimpleSagaEntitySaga(), new SimpleSagaEntity{ OrderSource = Guid.NewGuid().ToString() });
+
                 var simpleSageEntity = await persister.Get<SimpleSagaEntity>("propertyNotFound", "someValue", session, readContextBag);
                 Assert.IsNull(simpleSageEntity);
             }
@@ -26,6 +28,8 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
+                SetActiveSagaInstance(readContextBag, new SimpleSagaEntitySaga(), new SimpleSagaEntity{ OrderSource = Guid.NewGuid().ToString() });
+
                 var simpleSageEntity = await persister.Get<SimpleSagaEntity>(Guid.Empty, session, readContextBag);
                 Assert.IsNull(simpleSageEntity);
             }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
@@ -34,10 +34,11 @@
             savingContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
+                SetActiveSagaInstance(savingContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData(), typeof(CustomFinder));
                 var saga = await persister.Get<SagaWithoutCorrelationPropertyData>(sagaData.Id, session, savingContextBag);
-                saga.FoundByFinderProperty = updateValue;
                 SetActiveSagaInstance(savingContextBag, new SagaWithoutCorrelationProperty(), saga, typeof(CustomFinder));
 
+                saga.FoundByFinderProperty = updateValue;
                 await persister.Update(saga, session, savingContextBag);
                 await session.CompleteAsync();
             }
@@ -46,6 +47,7 @@
             SagaWithoutCorrelationPropertyData result;
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
+                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData(), typeof(CustomFinder));
                 result = await persister.Get<SagaWithoutCorrelationPropertyData>(sagaData.Id, readSession, readContextBag);
             }
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -29,8 +29,8 @@
             var updatingContext = configuration.GetContextBagForSagaStorage();
             using (var updateSession = await configuration.SynchronizedStorage.OpenSession(updatingContext))
             {
+                SetActiveSagaInstance(updatingContext, new SagaWithCorrelationProperty(), saga1);
                 saga1 = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, updateSession, updatingContext);
-
                 SetActiveSagaInstance(updatingContext, new SagaWithCorrelationProperty(), saga1);
 
                 await persister.Update(saga1, updateSession, updatingContext);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
@@ -25,11 +25,15 @@
 
             var winningContext = configuration.GetContextBagForSagaStorage();
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
+            SetActiveSagaInstance(winningContext, new TestSaga(), saga);
             var record = await persister.Get<TestSagaData>(saga.Id, winningSaveSession, winningContext);
+            SetActiveSagaInstance(winningContext, new TestSaga(), record);
 
             var losingContext = configuration.GetContextBagForSagaStorage();
             var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
+            SetActiveSagaInstance(losingContext, new TestSaga(), saga);
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
+            SetActiveSagaInstance(losingContext, new TestSaga(), staleRecord);
 
             record.DateTimeProperty = DateTime.Now;
             await persister.Update(record, winningSaveSession, winningContext);

--- a/src/NServiceBus.Persistence.ServiceFabric/Config/ServiceFabricPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Config/ServiceFabricPersistenceConfig.cs
@@ -9,7 +9,7 @@ namespace NServiceBus
     /// <summary>
     /// Configuration extensions for Service Fabric Persistence
     /// </summary>
-    public static class ServiceFabricPersistenceConfig
+    public static partial class ServiceFabricPersistenceConfig
     {
         /// <summary>
         /// Provides the state manager to the persistence.

--- a/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj
+++ b/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj
@@ -86,9 +86,17 @@
     <Compile Include="Outbox\OutboxStateManagerExtensions.cs" />
     <Compile Include="Outbox\StoredOutboxMessage.cs" />
     <Compile Include="Outbox\StoredTransportOperation.cs" />
+    <Compile Include="SagaPersister\Config\SagaSettings_Reader.cs" />
+    <Compile Include="SagaPersister\Config\SagaSettings_ServiceFabricPersistenceConfig.cs" />
+    <Compile Include="SagaPersister\Config\SagaSettings.cs" />
+    <Compile Include="SagaPersister\Config\SagaSettings_JSonSerializerSettings.cs" />
+    <Compile Include="SagaPersister\Config\SagaSettings_Writer.cs" />
+    <Compile Include="SagaPersister\ContextBagExtensions.cs" />
+    <Compile Include="SagaPersister\RuntimeSagaInfo.cs" />
     <Compile Include="SagaPersister\SagaEntry.cs" />
     <Compile Include="SagaPersister\SagaEntryExtensions.cs" />
     <Compile Include="SagaPersister\SagaIdGenerator.cs" />
+    <Compile Include="SagaPersister\SagaInfoCache.cs" />
     <Compile Include="SagaPersister\SagaStateManagerExtensions.cs" />
     <Compile Include="ServiceFabricPersistence.cs" />
     <Compile Include="Outbox\OutboxPersistenceFeature.cs" />
@@ -100,6 +108,7 @@
     <Compile Include="SagaPersister\SagaPersistenceFeature.cs" />
     <Compile Include="SagaPersister\SagaPersister.cs" />
     <Compile Include="ServiceFabricPersistenceStorageSessionExtensions.cs" />
+    <Compile Include="StaticVersions.cs" />
     <Compile Include="SynchronizedStorage\IServiceFabricStorageSession.cs" />
     <Compile Include="SynchronizedStorage\SynchronizedStorage.cs" />
     <Compile Include="SynchronizedStorage\StorageSession.cs" />

--- a/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj.DotSettings
+++ b/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=config/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sagapersister_005Cconfig/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=synchronizedstorage/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using Settings;
+
+    public partial class SagaSettings
+    {
+
+        SettingsHolder settings;
+
+        internal SagaSettings(SettingsHolder settings)
+        {
+            this.settings = settings;
+        }
+
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_JSonSerializerSettings.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_JSonSerializerSettings.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using Newtonsoft.Json;
+    using Settings;
+
+    public partial class SagaSettings
+    {
+        public void JsonSettings(JsonSerializerSettings jsonSerializerSettings)
+        {
+            settings.Set("ServiceFabricPersistence.Saga.JsonSerializerSettings", jsonSerializerSettings);
+        }
+
+        internal static JsonSerializerSettings GetJsonSerializerSettings(ReadOnlySettings settings)
+        {
+            return settings.GetOrDefault<JsonSerializerSettings>("ServiceFabricPersistence.Saga.JsonSerializerSettings");
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_Reader.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_Reader.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using System.IO;
+    using Newtonsoft.Json;
+    using Settings;
+
+    public partial class SagaSettings
+    {
+        public void ReaderCreator(Func<TextReader, JsonReader> readerCreator)
+        {
+            settings.Set("ServiceFabricPersistence.Saga.ReaderCreator", readerCreator);
+        }
+
+        internal static Func<TextReader, JsonReader> GetReaderCreator(ReadOnlySettings settings)
+        {
+            return settings.GetOrDefault<Func<TextReader, JsonReader>>("ServiceFabricPersistence.Saga.ReaderCreator");
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_ServiceFabricPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_ServiceFabricPersistenceConfig.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus
+{
+    using Configuration.AdvanceExtensibility;
+    using Persistence.ServiceFabric;
+
+    public static partial class ServiceFabricPersistenceConfig
+    {
+        public static SagaSettings SagaSettings(this PersistenceExtensions<ServiceFabricPersistence> configuration)
+        {
+            return new SagaSettings(configuration.GetSettings());
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_Writer.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/Config/SagaSettings_Writer.cs
@@ -1,0 +1,23 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Newtonsoft.Json;
+    using Settings;
+
+    public partial class SagaSettings
+    {
+
+        public void WriterCreator(Func<StringBuilder, JsonWriter> writerCreator)
+        {
+            settings.Set("ServiceFabricPersistence.Saga.WriterCreator", writerCreator);
+        }
+
+        internal static Func<TextWriter, JsonWriter> GetWriterCreator(ReadOnlySettings settings)
+        {
+            return settings.GetOrDefault<Func<TextWriter, JsonWriter>>("ServiceFabricPersistence.Saga.WriterCreator");
+        }
+
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/ContextBagExtensions.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/ContextBagExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using Extensibility;
+    using Sagas;
+
+    static class ContextBagExtentions
+    {
+        public static Type GetSagaType(this ContextBag context)
+        {
+            var activeSagaInstance = context.Get<ActiveSagaInstance>();
+            if (activeSagaInstance != null)
+            {
+                return activeSagaInstance.Instance.GetType();
+            }
+            throw new Exception($"Expected to find an instance of {nameof(ActiveSagaInstance)} in the {nameof(ContextBag)}.");
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/RuntimeSagaInfo.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/RuntimeSagaInfo.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Newtonsoft.Json;
+
+    class RuntimeSagaInfo
+    {
+        // ReSharper disable once NotAccessedField.Local
+        Type sagaDataType;
+        JsonSerializer jsonSerializer;
+        Func<TextReader, JsonReader> readerCreator;
+        Func<TextWriter, JsonWriter> writerCreator;
+
+        readonly Version CurrentVersion;
+
+        public RuntimeSagaInfo(Type sagaDataType,
+            // ReSharper disable once UnusedParameter.Local
+            Type sagaType,
+            JsonSerializer jsonSerializer,
+            Func<TextReader, JsonReader> readerCreator,
+            Func<TextWriter, JsonWriter> writerCreator)
+        {
+            this.sagaDataType = sagaDataType;
+            this.jsonSerializer = jsonSerializer;
+            this.readerCreator = readerCreator;
+            this.writerCreator = writerCreator;
+
+            CurrentVersion = sagaDataType.Assembly.GetFileVersion();
+        }
+
+        public SagaEntry ToSagaEntry(IContainSagaData sagaData)
+        {
+            var builder = new StringBuilder();
+            using (var stringWriter = new StringWriter(builder))
+            using (var writer = writerCreator(stringWriter))
+            {
+                jsonSerializer.Serialize(writer, sagaData);
+            }
+            return new SagaEntry(builder.ToString(), CurrentVersion, StaticVersions.PersistenceVersion);
+        }
+
+        public TSagaData FromEntry<TSagaData>(SagaEntry entry)
+            where TSagaData : IContainSagaData
+        {
+            using(var reader = new StringReader(entry.Data))
+            using (var jsonReader = readerCreator(reader))
+            {
+                return jsonSerializer.Deserialize<TSagaData>(jsonReader);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaEntry.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaEntry.cs
@@ -1,17 +1,26 @@
 namespace NServiceBus.Persistence.ServiceFabric
 {
+    using System;
     using System.Runtime.Serialization;
 
     [DataContract(Namespace = "NServiceBus.Persistence.ServiceFabric", Name = "SagaEntry")]
     sealed class SagaEntry : IExtensibleDataObject
     {
-        public SagaEntry(string data)
+        public SagaEntry(string data, Version sagaTypeVersion, Version persistenceVersion)
         {
             Data = data;
+            SagaTypeVersion = sagaTypeVersion;
+            PersistenceVersion = persistenceVersion;
         }
 
         [DataMember(Name = "Data", Order = 0)]
         public string Data { get; private set; }
+
+        [DataMember(Name = "PersistenceVersion", Order = 1)]
+        public Version PersistenceVersion { get; set; }
+
+        [DataMember(Name = "SagaTypeVersion", Order = 2)]
+        public Version SagaTypeVersion { get; set; }
 
         public ExtensionDataObject ExtensionData { get; set; }
     }

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaEntryExtensions.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaEntryExtensions.cs
@@ -4,11 +4,6 @@ namespace NServiceBus.Persistence.ServiceFabric
 
     static class SagaEntryExtensions
     {
-        public static TSagaData ToSagaData<TSagaData>(this SagaEntry entry)
-        {
-            return JsonConvert.DeserializeObject<TSagaData>(entry.Data);
-        }
-
         public static string FromSagaData(this IContainSagaData data)
         {
             return JsonConvert.SerializeObject(data);

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaInfoCache.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaInfoCache.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using Newtonsoft.Json;
+
+    class SagaInfoCache
+    {
+        JsonSerializer jsonSerializer;
+        Func<TextReader, JsonReader> readerCreator;
+        Func<TextWriter, JsonWriter> writerCreator;
+        ConcurrentDictionary<Type, RuntimeSagaInfo> serializerCache = new ConcurrentDictionary<Type, RuntimeSagaInfo>();
+
+        public SagaInfoCache() : this(null, null, null)
+        {
+        }
+
+        public SagaInfoCache(
+            JsonSerializerSettings jsonSerializerSettings,
+            Func<TextReader, JsonReader> readerCreator,
+            Func<TextWriter, JsonWriter> writerCreator)
+        {
+            this.writerCreator = writerCreator ?? (writer => new JsonTextWriter(writer));
+            this.readerCreator = readerCreator ?? (reader => new JsonTextReader(reader));
+            jsonSerializer = JsonSerializer.Create(jsonSerializerSettings ?? new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+                DefaultValueHandling = DefaultValueHandling.Ignore
+            });
+        }
+
+        public RuntimeSagaInfo GetInfo(Type sagaDataType, Type sagaType)
+        {
+            return serializerCache.GetOrAdd(sagaDataType, dataType => BuildSagaInfo(dataType, sagaType));
+        }
+
+        RuntimeSagaInfo BuildSagaInfo(Type sagaDataType, Type sagaType)
+        {
+            return new RuntimeSagaInfo(
+                sagaDataType,
+                sagaType,
+                jsonSerializer,
+                readerCreator,
+                writerCreator);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaPersistenceFeature.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SagaPersister/SagaPersistenceFeature.cs
@@ -16,12 +16,18 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var persister = new SagaPersister();
+            var settings = context.Settings;
+            var jsonSerializerSettings = SagaSettings.GetJsonSerializerSettings(settings);
+            var readerCreator = SagaSettings.GetReaderCreator(settings);
+            var writerCreator = SagaSettings.GetWriterCreator(settings);
+            var infoCache = new SagaInfoCache(jsonSerializerSettings, readerCreator, writerCreator);
+            var persister = new SagaPersister(infoCache);
 
             context.RegisterStartupTask(b => new RegisterDictionaries(context.Settings.StateManager(), persister));
 
             context.Container.RegisterSingleton<ISagaPersister>(persister);
         }
+
 
         class RegisterDictionaries : FeatureStartupTask
         {

--- a/src/NServiceBus.Persistence.ServiceFabric/StaticVersions.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/StaticVersions.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using System.Diagnostics;
+    using System.Reflection;
+
+    static class StaticVersions
+    {
+        public static readonly Version PersistenceVersion;
+
+        static StaticVersions()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            PersistenceVersion = GetFileVersion(assembly);
+        }
+
+        internal static Version GetFileVersion(this Assembly assembly)
+        {
+            var version = FileVersionInfo.GetVersionInfo(assembly.Location);
+            return new Version(
+                version.FileMajorPart,
+                version.FileMinorPart,
+                version.FileBuildPart,
+                version.FilePrivatePart);
+        }
+    }
+}

--- a/src/Tests/APIApprovals.ApprovePersistence.approved.txt
+++ b/src/Tests/APIApprovals.ApprovePersistence.approved.txt
@@ -9,6 +9,12 @@ namespace NServiceBus.Persistence.ServiceFabric
         Microsoft.ServiceFabric.Data.IReliableStateManager StateManager { get; }
         Microsoft.ServiceFabric.Data.ITransaction Transaction { get; }
     }
+    public class SagaSettings
+    {
+        public void JsonSettings(Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings) { }
+        public void ReaderCreator(System.Func<System.IO.TextReader, Newtonsoft.Json.JsonReader> readerCreator) { }
+        public void WriterCreator(System.Func<System.Text.StringBuilder, Newtonsoft.Json.JsonWriter> writerCreator) { }
+    }
     public class ServiceFabricPersistence : NServiceBus.Persistence.PersistenceDefinition { }
     public class static ServiceFabricPersistenceStorageSessionExtensions
     {
@@ -24,6 +30,7 @@ namespace NServiceBus
     }
     public class static ServiceFabricPersistenceConfig
     {
+        public static NServiceBus.Persistence.ServiceFabric.SagaSettings SagaSettings(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.ServiceFabric.ServiceFabricPersistence> configuration) { }
         public static void StateManager(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.ServiceFabric.ServiceFabricPersistence> configuration, Microsoft.ServiceFabric.Data.IReliableStateManager stateManager) { }
     }
 }


### PR DESCRIPTION
 Exposes the possibility to define json serializer settings for sagas. This is done very similar to Sql Persistence

Also added RuntimeSagaInfo that can hold collection prefixes if we decide to go that way, it would also allow us to define version specific deserializer settings similar to sql persistence when required. For the caching I required access to `ActiveSagaInstance`. That's why I had to augment the component tests a bit. The change now also makes it possible to use these tests with Sql Persistence (it also relies on `ActiveSagaInstance`).
