### PR TITLE
Test clean up - moving into a scenario-like approach

### DIFF
--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaPersisterTests.cs
@@ -6,6 +6,20 @@
     using NUnit.Framework;
     using Sagas;
 
+    public class SagaPersisterTests<TSaga, TSagaData> : SagaPersisterTests
+        where TSaga : Saga<TSagaData>, new()
+        where TSagaData : IContainSagaData, new()
+    {
+        protected Task SaveSaga(TSagaData saga, params Type[] availableTypes) => SaveSaga<TSaga, TSagaData>(saga, availableTypes);
+        protected Task<TSagaData> GetByIdAndComplete(Guid sagaId, params Type[] availableTypes) => GetByIdAndComplete<TSaga, TSagaData>(sagaId, availableTypes);
+        protected Task<TSagaData> GetByIdAndUpdate(Guid sagaId, Action<TSagaData> update, params Type[] availableTypes) => GetByIdAndUpdate<TSaga, TSagaData>(sagaId, update, availableTypes);
+        protected Task<TSagaData> GetByCorrelationPropertyAndUpdate(string correlatedPropertyName, object correlationPropertyData, Action<TSagaData> update) => GetByCorrelationPropertyAndUpdate<TSaga, TSagaData>(correlatedPropertyName, correlationPropertyData, update);
+        protected Task<TSagaData> GetByCorrelationPropertyAndComplete(string correlatedPropertyName, object correlationPropertyData) => GetByCorrelationPropertyAndComplete<TSaga, TSagaData>(correlatedPropertyName, correlationPropertyData);
+        protected Task<TSagaData> GetByCorrelationProperty(string correlatedPropertyName, object correlationPropertyData) => GetByCorrelationProperty<TSaga, TSagaData>(correlatedPropertyName, correlationPropertyData);
+        protected Task<TSagaData> GetById(Guid sagaId, params Type[] availableTypes) => GetById<TSaga, TSagaData>(sagaId, availableTypes);
+        protected SagaCorrelationProperty SetActiveSagaInstance(ContextBag context, TSaga saga, TSagaData sagaData, params Type[] availableTypes) => SetActiveSagaInstance<TSaga, TSagaData>(context, saga, sagaData, availableTypes);
+    }
+
     public class SagaPersisterTests
     {
         protected PersistenceTestsConfiguration configuration;
@@ -21,6 +35,132 @@
         public async Task OneTimeTearDown()
         {
             await configuration.Cleanup();
+        }
+
+        protected async Task SaveSaga<TSaga, TSagaData>(TSagaData saga, params Type[] availableTypes)
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : IContainSagaData, new()
+        {
+            var insertContextBag = configuration.GetContextBagForSagaStorage();
+            using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
+            {
+                var correlationProperty = SetActiveSagaInstance(insertContextBag, new TSaga(), saga, availableTypes);
+
+                await configuration.SagaStorage.Save(saga, correlationProperty, insertSession, insertContextBag);
+                await insertSession.CompleteAsync();
+            }
+        }
+
+        protected async Task<TSagaData> GetByIdAndComplete<TSaga, TSagaData>(Guid sagaId, params Type[] availableTypes)
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : IContainSagaData, new()
+        {
+            var context = configuration.GetContextBagForSagaStorage();
+            TSagaData sagaData;
+            var persister = configuration.SagaStorage;
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
+            {
+                SetActiveSagaInstance(context, new TSaga(), new TSagaData(), availableTypes);
+                sagaData = await persister.Get<TSagaData>(sagaId, completeSession, context);
+                SetActiveSagaInstance(context, new TSaga(), sagaData, availableTypes);
+
+                await persister.Complete(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
+            }
+            return sagaData;
+        }
+
+        protected async Task<TSagaData> GetByIdAndUpdate<TSaga, TSagaData>(Guid sagaId, Action<TSagaData> update, params Type[] availableTypes)
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : IContainSagaData, new()
+        {
+            var context = configuration.GetContextBagForSagaStorage();
+            TSagaData sagaData;
+            var persister = configuration.SagaStorage;
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
+            {
+                SetActiveSagaInstance(context, new TSaga(), new TSagaData(), availableTypes);
+                sagaData = await persister.Get<TSagaData>(sagaId, completeSession, context);
+                SetActiveSagaInstance(context, new TSaga(), sagaData, availableTypes);
+
+                update(sagaData);
+
+                await persister.Update(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
+            }
+            return sagaData;
+        }
+
+        protected async Task<TSagaData> GetByCorrelationPropertyAndUpdate<TSaga, TSagaData>(string correlatedPropertyName, object correlationPropertyData, Action<TSagaData> update)
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : IContainSagaData, new()
+        {
+            var context = configuration.GetContextBagForSagaStorage();
+            TSagaData sagaData;
+            var persister = configuration.SagaStorage;
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
+            {
+                SetActiveSagaInstance(context, new TSaga(), new TSagaData());
+
+                sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
+                SetActiveSagaInstance(context, new TSaga(), sagaData);
+
+                update(sagaData);
+
+                await persister.Update(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
+            }
+            return sagaData;
+        }
+
+        protected async Task<TSagaData> GetByCorrelationPropertyAndComplete<TSaga, TSagaData>(string correlatedPropertyName, object correlationPropertyData)
+           where TSaga : Saga<TSagaData>, new()
+           where TSagaData : IContainSagaData, new()
+        {
+            var context = configuration.GetContextBagForSagaStorage();
+            TSagaData sagaData;
+            var persister = configuration.SagaStorage;
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
+            {
+                SetActiveSagaInstance(context, new TSaga(), new TSagaData());
+
+                sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
+                SetActiveSagaInstance(context, new TSaga(), sagaData);
+
+                await persister.Complete(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
+            }
+            return sagaData;
+        }
+
+        protected async Task<TSagaData> GetByCorrelationProperty<TSaga, TSagaData>(string correlatedPropertyName, object correlationPropertyData)
+           where TSaga : Saga<TSagaData>, new()
+           where TSagaData : IContainSagaData, new()
+        {
+            var context = configuration.GetContextBagForSagaStorage();
+            TSagaData sagaData;
+            var persister = configuration.SagaStorage;
+
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
+            {
+                SetActiveSagaInstance(context, new TSaga(), new TSagaData());
+                sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
+            }
+            return sagaData;
+        }
+
+        protected async Task<TSagaData> GetById<TSaga, TSagaData>(Guid sagaId, params Type[] availableTypes)
+            where TSaga : Saga<TSagaData>, new()
+            where TSagaData : IContainSagaData, new()
+        {
+            var readContextBag = configuration.GetContextBagForSagaStorage();
+            TSagaData sagaData;
+            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
+            {
+                SetActiveSagaInstance(readContextBag, new TSaga(), new TSagaData(), availableTypes);
+                sagaData = await configuration.SagaStorage.Get<TSagaData>(sagaId, readSession, readContextBag);
+            }
+            return sagaData;
         }
 
         protected SagaCorrelationProperty SetActiveSagaInstance<TSaga, TSagaData>(ContextBag context, TSaga saga, TSagaData sagaData, params Type[] availableTypes)

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithComplexType.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithComplexType.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Persistence.ComponentTests
     using System;
     using System.Threading.Tasks;
 
-    class SagaWithComplexType : Saga<SagaWithComplexTypeEntity>, IAmStartedByMessages<StartMessage>
+    public class SagaWithComplexType : Saga<SagaWithComplexTypeEntity>, IAmStartedByMessages<StartMessage>
     {
         public Task Handle(StartMessage message, IMessageHandlerContext context)
         {

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithComplexTypeEntity.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithComplexTypeEntity.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Persistence.ComponentTests
 {
     using System.Collections.Generic;
 
-    class SagaWithComplexTypeEntity : ContainSagaData
+    public class SagaWithComplexTypeEntity : ContainSagaData
     {
         public string CorrelationProperty { get; set; }
         public List<int> Ints { get; set; }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithCorrelationPropertyData.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithCorrelationPropertyData.cs
@@ -18,6 +18,8 @@ namespace NServiceBus.Persistence.ComponentTests
     public class SagaWithCorrelationPropertyData : ContainSagaData
     {
         public string CorrelatedProperty { get; set; }
+
+        public DateTime DateTimeProperty { get; set; }
     }
 
     public class SagaCorrelationPropertyStartingMessage

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithCorrelationPropertyData.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithCorrelationPropertyData.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Persistence.ComponentTests
     using System;
     using System.Threading.Tasks;
 
-    class SagaWithCorrelationProperty : Saga<SagaWithCorrelationPropertyData>, IAmStartedByMessages<SagaCorrelationPropertyStartingMessage>
+    public class SagaWithCorrelationProperty : Saga<SagaWithCorrelationPropertyData>, IAmStartedByMessages<SagaCorrelationPropertyStartingMessage>
     {
         public Task Handle(SagaCorrelationPropertyStartingMessage message, IMessageHandlerContext context)
         {
@@ -20,7 +20,7 @@ namespace NServiceBus.Persistence.ComponentTests
         public string CorrelatedProperty { get; set; }
     }
 
-    class SagaCorrelationPropertyStartingMessage
+    public class SagaCorrelationPropertyStartingMessage
     {
         public string CorrelatedProperty { get; set; }
     }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithoutCorrelationPropertyData.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithoutCorrelationPropertyData.cs
@@ -5,7 +5,7 @@
     using Extensibility;
     using Sagas;
 
-    class SagaWithoutCorrelationProperty : Saga<SagaWithoutCorrelationPropertyData>, 
+    public class SagaWithoutCorrelationProperty : Saga<SagaWithoutCorrelationPropertyData>, 
         IAmStartedByMessages<SagaWithoutCorrelationPropertyStartingMessage>
     {
         public Task Handle(SagaWithoutCorrelationPropertyStartingMessage message, IMessageHandlerContext context)

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithoutCorrelationPropertyData.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaWithoutCorrelationPropertyData.cs
@@ -30,6 +30,8 @@
     public class SagaWithoutCorrelationPropertyData : ContainSagaData
     {
         public string FoundByFinderProperty { get; set; }
+
+        public DateTime DateTimeProperty { get; set; }
     }
 
     public class SagaWithoutCorrelationPropertyStartingMessage : IMessage

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SimpleSagaEntitySaga.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SimpleSagaEntitySaga.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Persistence.ComponentTests
     using System;
     using System.Threading.Tasks;
 
-    class SimpleSagaEntitySaga : Saga<SimpleSagaEntity>, IAmStartedByMessages<StartMessage>
+    public class SimpleSagaEntitySaga : Saga<SimpleSagaEntity>, IAmStartedByMessages<StartMessage>
     {
         public Task Handle(StartMessage message, IMessageHandlerContext context)
         {

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/TestSagaData.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/TestSagaData.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
+    public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
     {
         public Task Handle(StartMessage message, IMessageHandlerContext context)
         {
@@ -17,7 +17,7 @@
         }
     }
 
-    class StartMessage
+    public class StartMessage
     {
         public string SomeId { get; set; }
     }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/TestSagaData.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/TestSagaData.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
@@ -26,52 +25,6 @@
     {
         public string SomeId { get; set; } = "Test";
 
-        public RelatedClass RelatedClass { get; set; }
-
-        public IList<OrderLine> OrderLines { get; set; }
-
-        public StatusEnum Status { get; set; }
-
         public DateTime DateTimeProperty { get; set; }
-
-        public TestComponent TestComponent { get; set; }
-
-        public PolymorphicPropertyBase PolymorphicRelatedProperty { get; set; }
-    }
-
-    public class PolymorphicProperty : PolymorphicPropertyBase
-    {
-        public int SomeInt { get; set; }
-    }
-
-    public class PolymorphicPropertyBase
-    {
-        public Guid Id { get; set; }
-    }
-
-    public enum StatusEnum
-    {
-        SomeStatus,
-        AnotherStatus
-    }
-
-    public class TestComponent
-    {
-        public string Property { get; set; }
-        public string AnotherProperty { get; set; }
-    }
-
-    public class OrderLine
-    {
-        public Guid Id { get; set; }
-
-        public Guid ProductId { get; set; }
-    }
-
-    public class RelatedClass
-    {
-        public Guid Id { get; set; }
-
-        public TestSagaData ParentSaga { get; set; }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -5,45 +5,21 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_completing_a_saga_with_correlation_property : SagaPersisterTests
+    public class When_completing_a_saga_with_correlation_property : SagaPersisterTests<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>
     {
         [Test]
         public async Task Should_delete_the_saga()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 
-            var persister = configuration.SagaStorage;
+            var saga = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
 
-            var insertContextBag = configuration.GetContextBagForSagaStorage();
-            using (var savingSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
-            {
-                var saga = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
-                var correlationProperty = SetActiveSagaInstance(insertContextBag, new SagaWithCorrelationProperty(), saga);
+            await SaveSaga(saga);
 
-                await persister.Save(saga, correlationProperty, savingSession, insertContextBag);
-                await savingSession.CompleteAsync();
-            }
+            const string correlatedPropertyName = nameof(SagaWithCorrelationPropertyData.CorrelatedProperty);
 
-            var intentionallySharedContext = configuration.GetContextBagForSagaStorage();
-            SagaWithCorrelationPropertyData sagaData;
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
-            {
-                SetActiveSagaInstance(intentionallySharedContext, new SagaWithCorrelationProperty(), new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData });
-                sagaData = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, completeSession, intentionallySharedContext);
-                SetActiveSagaInstance(intentionallySharedContext, new SagaWithCorrelationProperty(), sagaData);
-
-                await persister.Complete(sagaData, completeSession, intentionallySharedContext );
-                await completeSession.CompleteAsync();
-            }
-
-            SagaWithCorrelationPropertyData completedSaga;
-            var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
-            {
-                SetActiveSagaInstance(readContextBag, new SagaWithCorrelationProperty(), new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData });
-
-                completedSaga = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, readSession, readContextBag);
-            }
+            var sagaData = await GetByCorrelationPropertyAndComplete(correlatedPropertyName, correlationPropertyData);
+            var completedSaga = await GetByCorrelationProperty(correlatedPropertyName, correlationPropertyData);
 
             Assert.NotNull(sagaData);
             Assert.Null(completedSaga);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
@@ -5,7 +5,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_completing_a_saga_with_no_defined_correlation_property : SagaPersisterTests
+    public class When_completing_a_saga_with_no_defined_correlation_property : SagaPersisterTests<SagaWithoutCorrelationProperty, SagaWithoutCorrelationPropertyData>
     {
         /// <summary>
         /// There can be a saga that is only started by a message and then is driven by timeouts only.
@@ -19,38 +19,16 @@
 
             var propertyData = Guid.NewGuid().ToString();
 
-            var persister = configuration.SagaStorage;
-            var savingContextBag = configuration.GetContextBagForSagaStorage();
-            Guid generatedSagaId;
-            using (var savingSession = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
-            {
-                var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData };
-                var correlationPropertyNone = SetActiveSagaInstance(savingContextBag, new SagaWithoutCorrelationProperty(), sagaData, typeof(CustomFinder));
-                generatedSagaId = sagaData.Id;
+            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData };
 
-                await persister.Save(sagaData, correlationPropertyNone, savingSession, savingContextBag);
-                await savingSession.CompleteAsync();
-            }
+            var finder = typeof(CustomFinder);
 
-            var completingContextBag = configuration.GetContextBagForSagaStorage();
-            using (var completingSession = await configuration.SynchronizedStorage.OpenSession(completingContextBag))
-            {
-                SetActiveSagaInstance(completingContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData(), typeof(CustomFinder));
-                var saga = await persister.Get<SagaWithoutCorrelationPropertyData>(generatedSagaId, completingSession, completingContextBag);
-                SetActiveSagaInstance(completingContextBag, new SagaWithoutCorrelationProperty(), saga, typeof(CustomFinder));
+            await SaveSaga(sagaData, finder);
 
-                await persister.Complete(saga, completingSession, completingContextBag);
-                await completingSession.CompleteAsync();
-            }
+            await GetByIdAndComplete(sagaData.Id, finder);
 
-            var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
-            {
-                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), new SagaWithoutCorrelationPropertyData { Id = generatedSagaId, FoundByFinderProperty = propertyData }, typeof(CustomFinder));
-
-                var result = await persister.Get<SagaWithoutCorrelationPropertyData>(generatedSagaId, readSession, readContextBag);
-                Assert.That(result, Is.Null);
-            }
+            var result = await GetById(sagaData.Id, finder);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.Persistence.ComponentTests
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
                 var sagaData = new TestSagaData { SomeId = correlationPropertyData };
-                var correlationProperty = SetActiveSagaInstance(insertContextBag, new TestSaga(), sagaData);
+                var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
                 await persister.Save(sagaData, correlationProperty, insertSession, insertContextBag);
@@ -33,9 +33,9 @@ namespace NServiceBus.Persistence.ComponentTests
             {
                 var winningContext = configuration.GetContextBagForSagaStorage();
                 var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
-                SetActiveSagaInstance(winningContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
                 var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
-                SetActiveSagaInstance(winningContext, new TestSaga(), record);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
                 startSecondTaskSync.SetResult(true);
                 await firstTaskCanCompleteSync.Task;
@@ -53,9 +53,9 @@ namespace NServiceBus.Persistence.ComponentTests
 
                 var losingSaveContext = configuration.GetContextBagForSagaStorage();
                 var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingSaveContext);
-                SetActiveSagaInstance(losingSaveContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
                 var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);
-                SetActiveSagaInstance(losingSaveContext, new TestSaga(), staleRecord);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, staleRecord);
 
                 firstTaskCanCompleteSync.SetResult(true);
                 await firstTask;

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs
@@ -18,7 +18,7 @@
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
                 var sagaData = new TestSagaData { SomeId = correlationPropertyData };
-                var correlationProperty = SetActiveSagaInstance(insertContextBag, new TestSaga(), sagaData);
+                var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
                 await persister.Save(sagaData, correlationProperty, insertSession, insertContextBag);
@@ -27,15 +27,15 @@
 
             var winningContext = configuration.GetContextBagForSagaStorage();
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
-            SetActiveSagaInstance(winningContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
             var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
-            SetActiveSagaInstance(winningContext, new TestSaga(), record);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
             var losingContext = configuration.GetContextBagForSagaStorage();
             var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-            SetActiveSagaInstance(losingContext, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
-            SetActiveSagaInstance(losingContext, new TestSaga(), staleRecord);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 
             record.DateTimeProperty = DateTime.Now;
             await persister.Update(record, winningSaveSession, winningContext);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Persistence.ComponentTests
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
                 var sagaData = new TestSagaData { SomeId = correlationPropertData };
-                SetActiveSagaInstance(savingContextBag, new TestSaga(), sagaData);
+                SetActiveSagaInstanceForSave(savingContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
                 await persister.Save(sagaData, null, session, savingContextBag);
@@ -45,13 +45,13 @@ namespace NServiceBus.Persistence.ComponentTests
                     var enlistedContextBag = configuration.GetContextBagForSagaStorage();
                     var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
 
-                    SetActiveSagaInstance(unenlistedContextBag, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
+                    SetActiveSagaInstanceForGet<TestSaga,TestSagaData>(unenlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
                     var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
-                    SetActiveSagaInstance(unenlistedContextBag, new TestSaga(), unenlistedRecord);
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, unenlistedRecord);
 
-                    SetActiveSagaInstance(enlistedContextBag, new TestSaga(), new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
                     var enlistedRecord = await persister.Get<TestSagaData>("Id", generatedSagaId, enlistedSession, enlistedContextBag);
-                    SetActiveSagaInstance(enlistedContextBag, new TestSaga(), enlistedRecord);
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, enlistedRecord);
 
                     await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag);
                     await persister.Update(enlistedRecord, enlistedSession, enlistedContextBag);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_complex_types.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_complex_types.cs
@@ -6,7 +6,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_persisting_a_saga_with_complex_types : SagaPersisterTests
+    public class When_persisting_a_saga_with_complex_types : SagaPersisterTests<SagaWithComplexType,SagaWithComplexTypeEntity>
     {
         [Test]
         public async Task It_should_get_deep_copy()
@@ -14,28 +14,12 @@
             var correlationPropertyData = Guid.NewGuid().ToString();
             var sagaData = new SagaWithComplexTypeEntity { Ints = new List<int> { 1, 2 }, CorrelationProperty = correlationPropertyData };
 
-            var persister = configuration.SagaStorage;
-            var savingContextBag = configuration.GetContextBagForSagaStorage();
-            Guid generatedSagaId;
-            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
-            {
-                var correlationProperty = SetActiveSagaInstance(savingContextBag, new SagaWithComplexType(), sagaData);
-                generatedSagaId = sagaData.Id;
+            await SaveSaga(sagaData);
 
-                await persister.Save(sagaData, correlationProperty, session, savingContextBag);
-                await session.CompleteAsync();
-            }
+            var retrieved = await GetById(sagaData.Id);
 
-            var readingContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
-            {
-                SetActiveSagaInstance(readingContextBag, new SagaWithComplexType(), sagaData);
-                var retrieved = await persister.Get<SagaWithComplexTypeEntity>(generatedSagaId, session, readingContextBag);
-                SetActiveSagaInstance(readingContextBag, new SagaWithComplexType(), retrieved);
-
-                CollectionAssert.AreEqual(sagaData.Ints, retrieved.Ints);
-                Assert.False(ReferenceEquals(sagaData.Ints, retrieved.Ints));
-            }
+            CollectionAssert.AreEqual(sagaData.Ints, retrieved.Ints);
+            Assert.False(ReferenceEquals(sagaData.Ints, retrieved.Ints));
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -3,54 +3,26 @@
     using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Sagas;
 
     [TestFixture]
-    public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga : SagaPersisterTests
+    public class When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga : SagaPersisterTests<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>
     {
         [Test]
         public async Task It_should_persist_successfully()
         {
-            var persister = configuration.SagaStorage;
-
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga1 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
             var saga2 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
+            var saga3 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
 
-            await SaveSaga(persister, saga1);
-            await CompleteSaga(persister, saga1);
+            await SaveSaga(saga1);
+            await GetByIdAndComplete(saga1.Id);
 
-            await SaveSaga(persister, saga2);
-            await CompleteSaga(persister, saga2);
+            await SaveSaga(saga2);
+            await GetByIdAndComplete(saga2.Id);
 
-            await SaveSaga(persister, saga1);
-            await CompleteSaga(persister, saga1);
-        }
-
-        async Task SaveSaga(ISagaPersister persister, SagaWithCorrelationPropertyData saga)
-        {
-            var savingContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
-            {
-                var correlationProperty = SetActiveSagaInstance(savingContextBag, new SagaWithCorrelationProperty(), saga);
-
-                await persister.Save(saga, correlationProperty, session, savingContextBag);
-                await session.CompleteAsync();
-            }
-        }
-
-        async Task CompleteSaga(ISagaPersister persister, SagaWithCorrelationPropertyData sagaData)
-        {
-            var completionContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(completionContextBag))
-            {
-                SetActiveSagaInstance(completionContextBag, new SagaWithCorrelationProperty(), sagaData);
-                var retrieved = await persister.Get<SagaWithCorrelationPropertyData>(sagaData.Id, session, completionContextBag);
-                SetActiveSagaInstance(completionContextBag, new SagaWithCorrelationProperty(), retrieved);
-
-                await persister.Complete(retrieved, session, completionContextBag);
-                await session.CompleteAsync();
-            }
+            await SaveSaga(saga3);
+            await GetByIdAndComplete(saga3.Id);
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -24,13 +24,13 @@
 
             var winningContextBag = configuration.GetContextBagForSagaStorage();
             var winningSession = await configuration.SynchronizedStorage.OpenSession(winningContextBag);
-            var correlationPropertySaga1 = SetActiveSagaInstance(winningContextBag, new SagaWithCorrelationProperty(), saga1);
+            var correlationPropertySaga1 = SetActiveSagaInstanceForSave(winningContextBag, new SagaWithCorrelationProperty(), saga1);
             await persister.Save(saga1, correlationPropertySaga1, winningSession, winningContextBag);
             await winningSession.CompleteAsync();
 
             var losingContextBag = configuration.GetContextBagForSagaStorage();
             var losingSession = await configuration.SynchronizedStorage.OpenSession(losingContextBag);
-            var correlationPropertySaga2 = SetActiveSagaInstance(losingContextBag, new SagaWithCorrelationProperty(), saga2);
+            var correlationPropertySaga2 = SetActiveSagaInstanceForSave(losingContextBag, new SagaWithCorrelationProperty(), saga2);
             await persister.Save(saga2, correlationPropertySaga2, losingSession, losingContextBag);
 
             Assert.That(async () => await losingSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"The saga with the correlation id 'Name: {nameof(SagaWithCorrelationPropertyData.CorrelatedProperty)} Value: {correlationPropertyData}' already exists."));

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
@@ -26,10 +26,10 @@ namespace NServiceBus.Persistence.ComponentTests
             var savingContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
-                var correlationPropertyNoneSaga1 = SetActiveSagaInstance(savingContextBag, new SagaWithoutCorrelationProperty(), saga1, typeof(CustomFinder));
+                var correlationPropertyNoneSaga1 = SetActiveSagaInstanceForSave(savingContextBag, new SagaWithoutCorrelationProperty(), saga1, typeof(CustomFinder));
                 await persister.Save(saga1, correlationPropertyNoneSaga1, session, savingContextBag);
 
-                var correlationPropertyNoneSaga2 = SetActiveSagaInstance(savingContextBag, new AnotherSagaWithoutCorrelationProperty(), saga2, typeof(AnotherCustomFinder));
+                var correlationPropertyNoneSaga2 = SetActiveSagaInstanceForSave(savingContextBag, new AnotherSagaWithoutCorrelationProperty(), saga2, typeof(AnotherCustomFinder));
                 await persister.Save(saga2, correlationPropertyNoneSaga2, session, savingContextBag);
 
                 await session.CompleteAsync();
@@ -38,10 +38,10 @@ namespace NServiceBus.Persistence.ComponentTests
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new SagaWithoutCorrelationProperty(), saga1, typeof(CustomFinder));
+                SetActiveSagaInstanceForGet<SagaWithoutCorrelationProperty, SagaWithoutCorrelationPropertyData>(readContextBag, saga1, typeof(CustomFinder));
                 var saga1Result = await persister.Get<SagaWithoutCorrelationPropertyData>(saga1.Id, readSession, readContextBag);
 
-                SetActiveSagaInstance(readContextBag, new AnotherSagaWithoutCorrelationProperty(), saga2, typeof(AnotherCustomFinder));
+                SetActiveSagaInstanceForGet<AnotherSagaWithoutCorrelationProperty, AnotherSagaWithoutCorrelationPropertyData>(readContextBag, saga2, typeof(AnotherCustomFinder));
                 var saga2Result = await persister.Get<AnotherSagaWithoutCorrelationPropertyData>(saga2.Id, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.FoundByFinderProperty, saga1Result.FoundByFinderProperty);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
@@ -24,10 +24,10 @@
             var savingContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
-                var correlationPropertySaga1 = SetActiveSagaInstance(savingContextBag, new SagaWithCorrelationProperty(), saga1);
+                var correlationPropertySaga1 = SetActiveSagaInstanceForSave(savingContextBag, new SagaWithCorrelationProperty(), saga1);
                 await persister.Save(saga1, correlationPropertySaga1, session, savingContextBag);
 
-                var correlationPropertySaga2 = SetActiveSagaInstance(savingContextBag, new AnotherSagaWithCorrelatedProperty(), saga2);
+                var correlationPropertySaga2 = SetActiveSagaInstanceForSave(savingContextBag, new AnotherSagaWithCorrelatedProperty(), saga2);
                 await persister.Save(saga2, correlationPropertySaga2, session, savingContextBag);
 
                 await session.CompleteAsync();
@@ -36,10 +36,10 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new SagaWithCorrelationProperty(), saga1);
+                SetActiveSagaInstanceForGet<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>(readContextBag, saga1);
                 var saga1Result = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), saga1.CorrelatedProperty, readSession, readContextBag);
 
-                SetActiveSagaInstance(readContextBag, new AnotherSagaWithCorrelatedProperty(), saga2);
+                SetActiveSagaInstanceForGet<AnotherSagaWithCorrelatedProperty, AnotherSagaWithCorrelatedPropertyData>(readContextBag, saga2);
                 var saga2Result = await persister.Get<AnotherSagaWithCorrelatedPropertyData>(nameof(AnotherSagaWithCorrelatedPropertyData.CorrelatedProperty), saga2.CorrelatedProperty, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.CorrelatedProperty, saga1Result.CorrelatedProperty);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Persistence.ComponentTests
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread : SagaPersisterTests
+    public class When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread : SagaPersisterTests<TestSaga, TestSagaData>
     {
         [Test]
         public async Task Save_throws_concurrency_violation()
@@ -13,16 +13,9 @@ namespace NServiceBus.Persistence.ComponentTests
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga = new TestSagaData { SomeId = correlationPropertyData};
 
+            await SaveSaga(saga);
             var persister = configuration.SagaStorage;
-            var insertContextBag = configuration.GetContextBagForSagaStorage();
-            using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
-            {
-                var correlationProperty = SetActiveSagaInstance(insertContextBag, new TestSaga(), saga);
-
-                await persister.Save(saga, correlationProperty, insertSession, insertContextBag);
-                await insertSession.CompleteAsync();
-            }
-
+            
             TestSagaData returnedSaga1;
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Persistence.ComponentTests
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstance(readContextBag, new TestSaga(), new TestSagaData());
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(readContextBag, new TestSagaData());
 
                 returnedSaga1 = await persister.Get<TestSagaData>(saga.Id, readSession, readContextBag);
 
@@ -31,14 +31,14 @@ namespace NServiceBus.Persistence.ComponentTests
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
 
             returnedSaga1.DateTimeProperty = DateTime.Now;
-            SetActiveSagaInstance(winningContext, new TestSaga(), returnedSaga1);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, returnedSaga1);
             await persister.Update(returnedSaga1, winningSaveSession, readContextBag);
             await winningSaveSession.CompleteAsync();
             winningSaveSession.Dispose();
 
             var losingContext = configuration.GetContextBagForSagaStorage();
             var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-            SetActiveSagaInstance(losingContext, new TestSaga(), returnedSaga1);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, returnedSaga1);
             await persister.Update(returnedSaga1, losingSaveSession, readContextBag);
 
             Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
@@ -54,7 +54,7 @@ namespace NServiceBus.Persistence.ComponentTests
             var insertContextBag = configuration.GetContextBagForSagaStorage();
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
-                var correlationProperty = SetActiveSagaInstance(insertContextBag, new TestSaga(), saga);
+                var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), saga);
 
                 await persister.Save(saga, correlationProperty, insertSession, insertContextBag);
                 await insertSession.CompleteAsync();
@@ -62,14 +62,14 @@ namespace NServiceBus.Persistence.ComponentTests
 
             var winningContext1 = configuration.GetContextBagForSagaStorage();
             var winningSaveSession1 = await configuration.SynchronizedStorage.OpenSession(winningContext1);
-            SetActiveSagaInstance(winningContext1, new TestSaga(), saga);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext1, saga);
             var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
 
             var losingContext1 = configuration.GetContextBagForSagaStorage();
             var losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1);
-            SetActiveSagaInstance(losingContext1, new TestSaga(), saga);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, saga);
             var staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
-            SetActiveSagaInstance(losingContext1, new TestSaga(), staleRecord1);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, staleRecord1);
 
             record1.DateTimeProperty = DateTime.Now;
             await persister.Update(record1, winningSaveSession1, winningContext1);
@@ -82,15 +82,15 @@ namespace NServiceBus.Persistence.ComponentTests
 
             var winningContext2 = configuration.GetContextBagForSagaStorage();
             var winningSaveSession2 = await configuration.SynchronizedStorage.OpenSession(winningContext2);
-            SetActiveSagaInstance(winningContext2, new TestSaga(), saga);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, saga);
             var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
-            SetActiveSagaInstance(winningContext2, new TestSaga(), record2);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, record2);
 
             var losingContext2 = configuration.GetContextBagForSagaStorage();
             var losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2);
-            SetActiveSagaInstance(losingContext2, new TestSaga(), saga);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, saga);
             var staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
-            SetActiveSagaInstance(losingContext2, new TestSaga(), staleRecord2);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, staleRecord2);
 
             record2.DateTimeProperty = DateTime.Now;
             await persister.Update(record2, winningSaveSession2, winningContext2);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_saga_not_found_return_default.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_saga_not_found_return_default.cs
@@ -5,34 +5,20 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_saga_not_found_return_default : SagaPersisterTests
+    public class When_saga_not_found_return_default : SagaPersisterTests<SimpleSagaEntitySaga, SimpleSagaEntity>
     {
         [Test]
         public async Task Should_return_default_when_using_finding_saga_with_property()
         {
-            var persister = configuration.SagaStorage;
-            var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(readContextBag))
-            {
-                SetActiveSagaInstance(readContextBag, new SimpleSagaEntitySaga(), new SimpleSagaEntity{ OrderSource = Guid.NewGuid().ToString() });
-
-                var simpleSageEntity = await persister.Get<SimpleSagaEntity>("propertyNotFound", "someValue", session, readContextBag);
-                Assert.IsNull(simpleSageEntity);
-            }
+            var result = await GetByCorrelationProperty("propertyNotFound", "someValue");
+            Assert.IsNull(result);
         }
 
         [Test]
         public async Task Should_return_default_when_using_finding_saga_with_id()
         {
-            var persister = configuration.SagaStorage;
-            var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(readContextBag))
-            {
-                SetActiveSagaInstance(readContextBag, new SimpleSagaEntitySaga(), new SimpleSagaEntity{ OrderSource = Guid.NewGuid().ToString() });
-
-                var simpleSageEntity = await persister.Get<SimpleSagaEntity>(Guid.Empty, session, readContextBag);
-                Assert.IsNull(simpleSageEntity);
-            }
+            var result = await GetById(Guid.Empty);
+            Assert.IsNull(result);
         }
 
         public class AnotherSimpleSagaEntity : ContainSagaData

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -18,7 +18,11 @@
 
             await SaveSaga(saga1);
 
-            await GetByCorrelationPropertyAndUpdate(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, _ => { });
+            var updatedValue = DateTime.UtcNow;
+            var result = await GetByCorrelationPropertyAndUpdate(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, saga => { saga.DateTimeProperty = updatedValue; });
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.DateTimeProperty, Is.EqualTo(updatedValue));
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -5,7 +5,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_updating_a_saga_with_the_same_unique_property_value : SagaPersisterTests
+    public class When_updating_a_saga_with_the_same_unique_property_value : SagaPersisterTests<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>
     {
         [Test]
         public async Task It_should_persist_successfully()
@@ -16,26 +16,9 @@
                 CorrelatedProperty = correlationPropertyData
             };
 
-            var persister = configuration.SagaStorage;
-            var insertContextBag = configuration.GetContextBagForSagaStorage();
-            using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
-            {
-                var correlationProperty = SetActiveSagaInstance(insertContextBag, new SagaWithCorrelationProperty(), saga1);
+            await SaveSaga(saga1);
 
-                await persister.Save(saga1, correlationProperty, insertSession, insertContextBag);
-                await insertSession.CompleteAsync();
-            }
-
-            var updatingContext = configuration.GetContextBagForSagaStorage();
-            using (var updateSession = await configuration.SynchronizedStorage.OpenSession(updatingContext))
-            {
-                SetActiveSagaInstance(updatingContext, new SagaWithCorrelationProperty(), saga1);
-                saga1 = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, updateSession, updatingContext);
-                SetActiveSagaInstance(updatingContext, new SagaWithCorrelationProperty(), saga1);
-
-                await persister.Update(saga1, updateSession, updatingContext);
-                await updateSession.CompleteAsync();
-            }
+            await GetByCorrelationPropertyAndUpdate(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), correlationPropertyData, _ => { });
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
@@ -19,15 +19,15 @@
 
             var winningContext = configuration.GetContextBagForSagaStorage();
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
-            SetActiveSagaInstance(winningContext, new TestSaga(), saga);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, saga);
             var record = await persister.Get<TestSagaData>(saga.Id, winningSaveSession, winningContext);
-            SetActiveSagaInstance(winningContext, new TestSaga(), record);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
             var losingContext = configuration.GetContextBagForSagaStorage();
             var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-            SetActiveSagaInstance(losingContext, new TestSaga(), saga);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, saga);
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
-            SetActiveSagaInstance(losingContext, new TestSaga(), staleRecord);
+            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 
             record.DateTimeProperty = DateTime.Now;
             await persister.Update(record, winningSaveSession, winningContext);


### PR DESCRIPTION
Common methods for different scenarios moved to the base test class. An additional generic test class added for removing the clutter of double generic parameters. Now they can be declared on the class level, which is the most common scenario.