### PR TITLE
Expose SagaEntry, StoredOutboxMessage and StoredTransportOperation as public contract

### DIFF
--- a/src/NServiceBus.Persistence.ServiceFabric/Outbox/StoredOutboxMessage.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Outbox/StoredOutboxMessage.cs
@@ -4,7 +4,7 @@
     using System.Runtime.Serialization;
 
     [DataContract(Namespace = "NServiceBus.Persistence.ServiceFabric", Name = "StoredOutboxMessage")]
-    sealed class StoredOutboxMessage : IExtensibleDataObject
+    public sealed class StoredOutboxMessage : IExtensibleDataObject
     {
         public StoredOutboxMessage(string messageId, StoredTransportOperation[] transportOperations)
         {

--- a/src/NServiceBus.Persistence.ServiceFabric/Outbox/StoredTransportOperation.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Outbox/StoredTransportOperation.cs
@@ -4,7 +4,7 @@
     using System.Runtime.Serialization;
 
     [DataContract(Namespace = "NServiceBus.Persistence.ServiceFabric", Name = "StoredOutboxMessage")]
-    class StoredTransportOperation : IExtensibleDataObject
+    public sealed class StoredTransportOperation : IExtensibleDataObject
     {
         [DataMember(Name = "MessageId", Order = 0)]
         public string MessageId { get; private set; }

--- a/src/NServiceBus.Persistence.ServiceFabric/Sagas/SagaEntry.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Sagas/SagaEntry.cs
@@ -4,7 +4,7 @@ namespace NServiceBus.Persistence.ServiceFabric
     using System.Runtime.Serialization;
 
     [DataContract(Namespace = "NServiceBus.Persistence.ServiceFabric", Name = "SagaEntry")]
-    sealed class SagaEntry : IExtensibleDataObject
+    public sealed class SagaEntry : IExtensibleDataObject
     {
         public SagaEntry(string data, Version sagaTypeVersion, Version persistenceVersion)
         {

--- a/src/Tests/APIApprovals.ApprovePersistence.approved.txt
+++ b/src/Tests/APIApprovals.ApprovePersistence.approved.txt
@@ -10,6 +10,18 @@ namespace NServiceBus.Persistence.ServiceFabric
         Microsoft.ServiceFabric.Data.IReliableStateManager StateManager { get; }
         Microsoft.ServiceFabric.Data.ITransaction Transaction { get; }
     }
+    [System.Runtime.Serialization.DataContractAttribute(Name="SagaEntry", Namespace="NServiceBus.Persistence.ServiceFabric")]
+    public sealed class SagaEntry : System.Runtime.Serialization.IExtensibleDataObject
+    {
+        public SagaEntry(string data, System.Version sagaTypeVersion, System.Version persistenceVersion) { }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="Data", Order=0)]
+        public string Data { get; }
+        public System.Runtime.Serialization.ExtensionDataObject ExtensionData { get; set; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="PersistenceVersion", Order=1)]
+        public System.Version PersistenceVersion { get; set; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="SagaTypeVersion", Order=2)]
+        public System.Version SagaTypeVersion { get; set; }
+    }
     public class SagaSettings
     {
         public void JsonSettings(Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings) { }
@@ -27,6 +39,37 @@ namespace NServiceBus.Persistence.ServiceFabric
         public string CollectionName;
         public string SagaDataName;
         public ServiceFabricSagaAttribute() { }
+    }
+    [System.Runtime.Serialization.DataContractAttribute(Name="StoredOutboxMessage", Namespace="NServiceBus.Persistence.ServiceFabric")]
+    public sealed class StoredOutboxMessage : System.Runtime.Serialization.IExtensibleDataObject
+    {
+        public StoredOutboxMessage(string messageId, NServiceBus.Persistence.ServiceFabric.StoredTransportOperation[] transportOperations) { }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="Dispatched", Order=1)]
+        public bool Dispatched { get; }
+        public System.Runtime.Serialization.ExtensionDataObject ExtensionData { get; set; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="Id", Order=0)]
+        public string Id { get; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="StoredAt", Order=2)]
+        public System.DateTimeOffset StoredAt { get; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="TransportOperations", Order=3)]
+        public NServiceBus.Persistence.ServiceFabric.StoredTransportOperation[] TransportOperations { get; }
+        public NServiceBus.Persistence.ServiceFabric.StoredOutboxMessage CloneAndMarkAsDispatched() { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    [System.Runtime.Serialization.DataContractAttribute(Name="StoredOutboxMessage", Namespace="NServiceBus.Persistence.ServiceFabric")]
+    public sealed class StoredTransportOperation : System.Runtime.Serialization.IExtensibleDataObject
+    {
+        public StoredTransportOperation(string messageId, System.Collections.Generic.Dictionary<string, string> options, byte[] body, System.Collections.Generic.Dictionary<string, string> headers) { }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="Body", Order=2)]
+        public byte[] Body { get; }
+        public System.Runtime.Serialization.ExtensionDataObject ExtensionData { get; set; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="Headers", Order=3)]
+        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="MessageId", Order=0)]
+        public string MessageId { get; }
+        [System.Runtime.Serialization.DataMemberAttribute(Name="Options", Order=1)]
+        public System.Collections.Generic.Dictionary<string, string> Options { get; }
     }
 }
 namespace NServiceBus


### PR DESCRIPTION
Apparently, it is not possible to redefine the data contract with reliable collections in a different assembly. So when you copy the SagaEntry into your assembly and even make the namespace match, then access inside the persister to that collection will fail with invalid cast exception. 

## Steps to repro

1. Copy paste i.ex. SagaEntry to own assembly.
1. Do a `GetOrAdd<IReliableDictionary<Guid, SagaEntry> `for a given saga data collection before the persister will store any saga
1. Observe messages moved to the error queue containing `InvalidCastException`

I'd say let's expose the data contract since we need to carefully version it anyway

