### PR TITLE
Component test fix

### DIFF
--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/SagaPersisterTests.cs
@@ -145,6 +145,8 @@
                 SetActiveSagaInstanceForGet<TSaga, TSagaData>(context, new TSagaData());
 
                 sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
+
+                await completeSession.CompleteAsync();
             }
             return sagaData;
         }
@@ -159,6 +161,8 @@
             {
                 SetActiveSagaInstanceForGet<TSaga, TSagaData>(readContextBag, new TSagaData(), availableTypes);
                 sagaData = await configuration.SagaStorage.Get<TSagaData>(sagaId, readSession, readContextBag);
+
+                await readSession.CompleteAsync();
             }
             return sagaData;
         }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_loaded_by_id.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_loaded_by_id.cs
@@ -12,7 +12,7 @@
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 
-            var saga = new TestSagaData { SomeId = correlationPropertyData };
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -12,7 +12,7 @@
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 
-            var saga = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
+            var saga = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
@@ -9,7 +9,7 @@
     {
         /// <summary>
         /// There can be a saga that is only started by a message and then is driven by timeouts only.
-        /// This kind of saga would not require to be correlated by any property. This test ensures that in-memory persistence covers this case and can handle this kind of sagas properly.
+        /// This kind of saga would not require to be correlated by any property.
         /// </summary>
         /// <returns></returns>
         [Test]

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_completing_a_saga_with_no_defined_correlation_property.cs
@@ -19,7 +19,7 @@
 
             var propertyData = Guid.NewGuid().ToString();
 
-            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData };
+            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData, DateTimeProperty = DateTime.UtcNow };
 
             var finder = typeof(CustomFinder);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
@@ -1,3 +1,4 @@
+// ReSharper disable AccessToDisposedClosure
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
@@ -32,19 +33,19 @@ namespace NServiceBus.Persistence.ComponentTests
             var firstTask = Task.Run(async () =>
             {
                 var winningContext = configuration.GetContextBagForSagaStorage();
-                var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
-                var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
+                using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext))
+                {
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                    var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
-                startSecondTaskSync.SetResult(true);
-                await firstTaskCanCompleteSync.Task;
+                    startSecondTaskSync.SetResult(true);
+                    await firstTaskCanCompleteSync.Task;
 
-                record.DateTimeProperty = DateTime.UtcNow;
-                await persister.Update(record, winningSaveSession, winningContext);
-                await winningSaveSession.CompleteAsync();
-                winningSaveSession.Dispose();
-
+                    record.DateTimeProperty = DateTime.UtcNow;
+                    await persister.Update(record, winningSaveSession, winningContext);
+                    await winningSaveSession.CompleteAsync();
+                }
             });
 
             var secondTask = Task.Run(async () =>
@@ -52,17 +53,19 @@ namespace NServiceBus.Persistence.ComponentTests
                 await startSecondTaskSync.Task;
 
                 var losingSaveContext = configuration.GetContextBagForSagaStorage();
-                var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingSaveContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
-                var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, staleRecord);
+                using (var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingSaveContext))
+                {
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertyData });
+                    var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);
+                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, staleRecord);
 
-                firstTaskCanCompleteSync.SetResult(true);
-                await firstTask;
+                    firstTaskCanCompleteSync.SetResult(true);
+                    await firstTask;
 
-                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
-                await persister.Update(staleRecord, losingSaveSession, losingSaveContext);
-                Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{generatedSagaId}] already saved."));
+                    staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
+                    await persister.Update(staleRecord, losingSaveSession, losingSaveContext);
+                    Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{generatedSagaId}] already saved."));
+                }
             });
 
             await secondTask;

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_different_threads.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Persistence.ComponentTests
             Guid generatedSagaId;
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
-                var sagaData = new TestSagaData { SomeId = correlationPropertyData };
+                var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
                 var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
@@ -40,7 +40,7 @@ namespace NServiceBus.Persistence.ComponentTests
                 startSecondTaskSync.SetResult(true);
                 await firstTaskCanCompleteSync.Task;
 
-                record.DateTimeProperty = DateTime.Now;
+                record.DateTimeProperty = DateTime.UtcNow;
                 await persister.Update(record, winningSaveSession, winningContext);
                 await winningSaveSession.CompleteAsync();
                 winningSaveSession.Dispose();
@@ -60,7 +60,7 @@ namespace NServiceBus.Persistence.ComponentTests
                 firstTaskCanCompleteSync.SetResult(true);
                 await firstTask;
 
-                staleRecord.DateTimeProperty = DateTime.Now.AddHours(1);
+                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 await persister.Update(staleRecord, losingSaveSession, losingSaveContext);
                 Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{generatedSagaId}] already saved."));
             });

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs
@@ -17,7 +17,7 @@
             Guid generatedSagaId;
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
-                var sagaData = new TestSagaData { SomeId = correlationPropertyData };
+                var sagaData = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
                 var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
                 generatedSagaId = sagaData.Id;
 
@@ -37,7 +37,7 @@
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
             SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 
-            record.DateTimeProperty = DateTime.Now;
+            record.DateTimeProperty = DateTime.UtcNow;
             await persister.Update(record, winningSaveSession, winningContext);
             await winningSaveSession.CompleteAsync();
             winningSaveSession.Dispose();

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Persistence.ComponentTests
     public class When_persisting_a_saga_with_an_escalated_DTC_transaction : SagaPersisterTests
     {
         [Test]
-        public async Task Save_should_fails_when_data_changes_between_concurrent_instances()
+        public async Task Save_should_fail_when_data_changes_between_concurrent_instances()
         {
             configuration.RequiresDtcSupport();
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Persistence.ComponentTests
     public class When_persisting_a_saga_with_an_escalated_DTC_transaction : SagaPersisterTests
     {
         [Test]
-        public async Task Save_fails_when_data_changes_between_concurrent_instances()
+        public async Task Save_should_fails_when_data_changes_between_concurrent_instances()
         {
             configuration.RequiresDtcSupport();
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -40,23 +40,24 @@ namespace NServiceBus.Persistence.ComponentTests
                     transportTransaction.Set(Transaction.Current);
 
                     var unenlistedContextBag = configuration.GetContextBagForSagaStorage();
-                    var unenlistedSession = await configuration.SynchronizedStorage.OpenSession(unenlistedContextBag);
+                    using (var unenlistedSession = await configuration.SynchronizedStorage.OpenSession(unenlistedContextBag))
+                    {
+                        var enlistedContextBag = configuration.GetContextBagForSagaStorage();
+                        var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
 
-                    var enlistedContextBag = configuration.GetContextBagForSagaStorage();
-                    var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
+                        SetActiveSagaInstanceForGet<TestSaga,TestSagaData>(unenlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
+                        var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
+                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, unenlistedRecord);
 
-                    SetActiveSagaInstanceForGet<TestSaga,TestSagaData>(unenlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
-                    var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, unenlistedRecord);
+                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
+                        var enlistedRecord = await persister.Get<TestSagaData>("Id", generatedSagaId, enlistedSession, enlistedContextBag);
+                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, enlistedRecord);
 
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, new TestSagaData { Id = generatedSagaId, SomeId = correlationPropertData });
-                    var enlistedRecord = await persister.Get<TestSagaData>("Id", generatedSagaId, enlistedSession, enlistedContextBag);
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, enlistedRecord);
+                        await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag);
+                        await persister.Update(enlistedRecord, enlistedSession, enlistedContextBag);
 
-                    await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag);
-                    await persister.Update(enlistedRecord, enlistedSession, enlistedContextBag);
-
-                    await unenlistedSession.CompleteAsync();
+                        await unenlistedSession.CompleteAsync();
+                    }
 
                     tx.Complete();
                 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_no_defined_unique_property.cs
@@ -13,7 +13,7 @@
             configuration.RequiresFindersSupport();
 
             var propertyData = Guid.NewGuid().ToString();
-            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData };
+            var sagaData = new SagaWithoutCorrelationPropertyData { FoundByFinderProperty = propertyData, DateTimeProperty = DateTime.UtcNow };
 
             var finder = typeof(CustomFinder);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -11,9 +11,9 @@
         public async Task It_should_persist_successfully()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga1 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
-            var saga2 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
-            var saga3 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData };
+            var saga1 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga2 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
+            var saga3 = new SagaWithCorrelationPropertyData { CorrelatedProperty = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             await SaveSaga(saga1);
             await GetByIdAndComplete(saga1.Id);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -25,17 +25,22 @@
             var persister = configuration.SagaStorage;
 
             var winningContextBag = configuration.GetContextBagForSagaStorage();
-            var winningSession = await configuration.SynchronizedStorage.OpenSession(winningContextBag);
-            var correlationPropertySaga1 = SetActiveSagaInstanceForSave(winningContextBag, new SagaWithCorrelationProperty(), saga1);
-            await persister.Save(saga1, correlationPropertySaga1, winningSession, winningContextBag);
-            await winningSession.CompleteAsync();
+            using (var winningSession = await configuration.SynchronizedStorage.OpenSession(winningContextBag))
+            {
+                var correlationPropertySaga1 = SetActiveSagaInstanceForSave(winningContextBag, new SagaWithCorrelationProperty(), saga1);
+                await persister.Save(saga1, correlationPropertySaga1, winningSession, winningContextBag);
+                await winningSession.CompleteAsync();
+            }
 
             var losingContextBag = configuration.GetContextBagForSagaStorage();
-            var losingSession = await configuration.SynchronizedStorage.OpenSession(losingContextBag);
-            var correlationPropertySaga2 = SetActiveSagaInstanceForSave(losingContextBag, new SagaWithCorrelationProperty(), saga2);
-            await persister.Save(saga2, correlationPropertySaga2, losingSession, losingContextBag);
+            using (var losingSession = await configuration.SynchronizedStorage.OpenSession(losingContextBag))
+            {
+                var correlationPropertySaga2 = SetActiveSagaInstanceForSave(losingContextBag, new SagaWithCorrelationProperty(), saga2);
+                await persister.Save(saga2, correlationPropertySaga2, losingSession, losingContextBag);
 
-            Assert.That(async () => await losingSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"The saga with the correlation id 'Name: {nameof(SagaWithCorrelationPropertyData.CorrelatedProperty)} Value: {correlationPropertyData}' already exists."));
+                // ReSharper disable once AccessToDisposedClosure
+                Assert.That(async () => await losingSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"The saga with the correlation id 'Name: {nameof(SagaWithCorrelationPropertyData.CorrelatedProperty)} Value: {correlationPropertyData}' already exists."));
+            }
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -13,11 +13,13 @@
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga1 = new SagaWithCorrelationPropertyData
             {
-                CorrelatedProperty = correlationPropertyData
+                CorrelatedProperty = correlationPropertyData,
+                DateTimeProperty = DateTime.UtcNow
             };
             var saga2 = new SagaWithCorrelationPropertyData
             {
-                CorrelatedProperty = correlationPropertyData
+                CorrelatedProperty = correlationPropertyData,
+                DateTimeProperty = DateTime.UtcNow
             };
 
             var persister = configuration.SagaStorage;

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
@@ -15,7 +15,8 @@ namespace NServiceBus.Persistence.ComponentTests
             var propertyData = Guid.NewGuid().ToString();
             var saga1 = new SagaWithoutCorrelationPropertyData
             {
-                FoundByFinderProperty = propertyData
+                FoundByFinderProperty = propertyData,
+                DateTimeProperty = DateTime.UtcNow
             };
             var saga2 = new AnotherSagaWithoutCorrelationPropertyData
             {

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_different_sagas_with_unique_properties.cs
@@ -13,11 +13,12 @@
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga1 = new SagaWithCorrelationPropertyData
             {
-                CorrelatedProperty = correlationPropertyData
+                CorrelatedProperty = correlationPropertyData,
+                DateTimeProperty = DateTime.UtcNow
             };
             var saga2 = new AnotherSagaWithCorrelatedPropertyData
             {
-                CorrelatedProperty = correlationPropertyData
+                CorrelatedProperty = correlationPropertyData,
             };
 
             var persister = configuration.SagaStorage;

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Persistence.ComponentTests
         public async Task Save_throws_concurrency_violation()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData};
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             await SaveSaga(saga);
             var persister = configuration.SagaStorage;
@@ -30,7 +30,7 @@ namespace NServiceBus.Persistence.ComponentTests
             var winningContext = configuration.GetContextBagForSagaStorage();
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
 
-            returnedSaga1.DateTimeProperty = DateTime.Now;
+            returnedSaga1.DateTimeProperty = DateTime.UtcNow;
             SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, returnedSaga1);
             await persister.Update(returnedSaga1, winningSaveSession, readContextBag);
             await winningSaveSession.CompleteAsync();
@@ -48,7 +48,7 @@ namespace NServiceBus.Persistence.ComponentTests
         public async Task Save_process_is_repeatable()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData };
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             var persister = configuration.SagaStorage;
             var insertContextBag = configuration.GetContextBagForSagaStorage();
@@ -71,7 +71,7 @@ namespace NServiceBus.Persistence.ComponentTests
             var staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
             SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, staleRecord1);
 
-            record1.DateTimeProperty = DateTime.Now;
+            record1.DateTimeProperty = DateTime.UtcNow;
             await persister.Update(record1, winningSaveSession1, winningContext1);
             await winningSaveSession1.CompleteAsync();
             winningSaveSession1.Dispose();
@@ -92,7 +92,7 @@ namespace NServiceBus.Persistence.ComponentTests
             var staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
             SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, staleRecord2);
 
-            record2.DateTimeProperty = DateTime.Now;
+            record2.DateTimeProperty = DateTime.UtcNow;
             await persister.Update(record2, winningSaveSession2, winningContext2);
             await winningSaveSession2.CompleteAsync();
             winningSaveSession2.Dispose();

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -10,45 +10,6 @@ namespace NServiceBus.Persistence.ComponentTests
     public class When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread : SagaPersisterTests<TestSaga, TestSagaData>
     {
         [Test]
-        public async Task Save_throws_concurrency_violation()
-        {
-            var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
-
-            await SaveSaga(saga);
-            var persister = configuration.SagaStorage;
-            
-            TestSagaData returnedSaga1;
-            var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
-            {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(readContextBag, new TestSagaData());
-
-                returnedSaga1 = await persister.Get<TestSagaData>(saga.Id, readSession, readContextBag);
-
-                await readSession.CompleteAsync();
-            }
-
-            var winningContext = configuration.GetContextBagForSagaStorage();
-            using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext))
-            {
-                returnedSaga1.DateTimeProperty = DateTime.UtcNow;
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, returnedSaga1);
-                await persister.Update(returnedSaga1, winningSaveSession, readContextBag);
-                await winningSaveSession.CompleteAsync();
-            }
-
-            var losingContext = configuration.GetContextBagForSagaStorage();
-            using (var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext))
-            {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, returnedSaga1);
-                await persister.Update(returnedSaga1, losingSaveSession, readContextBag);
-
-                Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
-            }
-        }
-
-        [Test]
         public async Task Save_process_is_repeatable()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -1,7 +1,9 @@
+// ReSharper disable AccessToDisposedClosure
 namespace NServiceBus.Persistence.ComponentTests
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using NUnit.Framework;
 
     [TestFixture]
@@ -28,20 +30,22 @@ namespace NServiceBus.Persistence.ComponentTests
             }
 
             var winningContext = configuration.GetContextBagForSagaStorage();
-            var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
-
-            returnedSaga1.DateTimeProperty = DateTime.UtcNow;
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, returnedSaga1);
-            await persister.Update(returnedSaga1, winningSaveSession, readContextBag);
-            await winningSaveSession.CompleteAsync();
-            winningSaveSession.Dispose();
+            using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext))
+            {
+                returnedSaga1.DateTimeProperty = DateTime.UtcNow;
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, returnedSaga1);
+                await persister.Update(returnedSaga1, winningSaveSession, readContextBag);
+                await winningSaveSession.CompleteAsync();
+            }
 
             var losingContext = configuration.GetContextBagForSagaStorage();
-            var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, returnedSaga1);
-            await persister.Update(returnedSaga1, losingSaveSession, readContextBag);
+            using (var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext))
+            {
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, returnedSaga1);
+                await persister.Update(returnedSaga1, losingSaveSession, readContextBag);
 
-            Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
+                Assert.That(async () => await losingSaveSession.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
+            }
         }
 
         [Test]
@@ -60,46 +64,79 @@ namespace NServiceBus.Persistence.ComponentTests
                 await insertSession.CompleteAsync();
             }
 
+            ContextBag losingContext1;
+            CompletableSynchronizedStorageSession losingSaveSession1;
+            TestSagaData staleRecord1;
+
             var winningContext1 = configuration.GetContextBagForSagaStorage();
             var winningSaveSession1 = await configuration.SynchronizedStorage.OpenSession(winningContext1);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext1, saga);
-            var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
 
-            var losingContext1 = configuration.GetContextBagForSagaStorage();
-            var losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, saga);
-            var staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, staleRecord1);
+            try
+            {
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext1, saga);
+                var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
 
-            record1.DateTimeProperty = DateTime.UtcNow;
-            await persister.Update(record1, winningSaveSession1, winningContext1);
-            await winningSaveSession1.CompleteAsync();
-            winningSaveSession1.Dispose();
+                losingContext1 = configuration.GetContextBagForSagaStorage();
+                losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, saga);
+                staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, staleRecord1);
 
-            await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
-            Assert.That(async () => await losingSaveSession1.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
-            losingSaveSession1.Dispose();
+                record1.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record1, winningSaveSession1, winningContext1);
+                await winningSaveSession1.CompleteAsync();
+            }
+            finally
+            {
+                winningSaveSession1.Dispose();
+            }
+
+            try
+            {
+                await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
+                Assert.That(async () => await losingSaveSession1.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
+            }
+            finally
+            {
+                losingSaveSession1.Dispose();
+            }
+
+            ContextBag losingContext2;
+            CompletableSynchronizedStorageSession losingSaveSession2;
+            TestSagaData staleRecord2;
 
             var winningContext2 = configuration.GetContextBagForSagaStorage();
             var winningSaveSession2 = await configuration.SynchronizedStorage.OpenSession(winningContext2);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, saga);
-            var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, record2);
+            try
+            {
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, saga);
+                var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, record2);
 
-            var losingContext2 = configuration.GetContextBagForSagaStorage();
-            var losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, saga);
-            var staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
-            SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, staleRecord2);
+                losingContext2 = configuration.GetContextBagForSagaStorage();
+                losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, saga);
+                staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
+                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, staleRecord2);
 
-            record2.DateTimeProperty = DateTime.UtcNow;
-            await persister.Update(record2, winningSaveSession2, winningContext2);
-            await winningSaveSession2.CompleteAsync();
-            winningSaveSession2.Dispose();
+                record2.DateTimeProperty = DateTime.UtcNow;
+                await persister.Update(record2, winningSaveSession2, winningContext2);
+                await winningSaveSession2.CompleteAsync();
+            }
+            finally
+            {
+                winningSaveSession2.Dispose();
+            }
 
-            await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
-            Assert.That(async () => await losingSaveSession2.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
-            losingSaveSession2.Dispose();
+            try
+            {
+                await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
+                Assert.That(async () => await losingSaveSession2.CompleteAsync(), Throws.InstanceOf<Exception>().And.Message.EndsWith($"concurrency violation: saga entity Id[{saga.Id}] already saved."));
+            }
+            finally
+            {
+                losingSaveSession2.Dispose();
+            }
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Persistence.ComponentTests
     public class When_retrieving_same_saga_on_different_threads : SagaPersisterTests
     {
         [Test]
-        public async Task Save_should_fails_when_data_changes_between_read_and_update_on_same_thread()
+        public async Task Save_should_fail_when_data_changes_between_read_and_update_on_same_thread()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_different_threads.cs
@@ -6,10 +6,10 @@ namespace NServiceBus.Persistence.ComponentTests
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_multiple_workers_retrieve_same_saga_on_different_threads : SagaPersisterTests
+    public class When_retrieving_same_saga_on_different_threads : SagaPersisterTests
     {
         [Test]
-        public async Task Save_fails_when_data_changes_between_read_and_update_on_same_thread()
+        public async Task Save_should_fails_when_data_changes_between_read_and_update_on_same_thread()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Persistence.ComponentTests
     public class When_retrieving_same_saga_on_the_same_thread : SagaPersisterTests
     {
         [Test]
-        public async Task Save_should_fails_when_data_changes_between_read_and_update()
+        public async Task Save_should_fail_when_data_changes_between_read_and_update()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
@@ -7,10 +7,10 @@ namespace NServiceBus.Persistence.ComponentTests
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_multiple_workers_retrieve_same_saga_on_the_same_thread : SagaPersisterTests
+    public class When_retrieving_same_saga_on_the_same_thread : SagaPersisterTests
     {
         [Test]
-        public async Task Save_fails_when_data_changes_between_read_and_update()
+        public async Task Save_should_fails_when_data_changes_between_read_and_update()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_the_same_saga_twice.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_retrieving_the_same_saga_twice.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Persistence.ComponentTests
         public async Task Get_returns_different_instance_of_saga_data()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData };
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             await SaveSaga(saga);
 

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
@@ -15,7 +15,8 @@
             var propertyData = Guid.NewGuid().ToString();
             var sagaData = new SagaWithoutCorrelationPropertyData
             {
-                FoundByFinderProperty = propertyData
+                FoundByFinderProperty = propertyData,
+                DateTimeProperty = DateTime.UtcNow
             };
 
             var finder = typeof(CustomFinder);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -13,7 +13,8 @@
             var correlationPropertyData = Guid.NewGuid().ToString();
             var saga1 = new SagaWithCorrelationPropertyData
             {
-                CorrelatedProperty = correlationPropertyData
+                CorrelatedProperty = correlationPropertyData,
+                DateTimeProperty = DateTime.UtcNow
             };
 
             await SaveSaga(saga1);

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/ComponentTests/Sagas/When_worker_tries_to_complete_saga_update_by_another.cs
@@ -11,7 +11,7 @@
         public async Task Should_fail()
         {
             var correlationPropertyData = Guid.NewGuid().ToString();
-            var saga = new TestSagaData { SomeId = correlationPropertyData };
+            var saga = new TestSagaData { SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow };
 
             await SaveSaga(saga);
 
@@ -29,7 +29,7 @@
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
             SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 
-            record.DateTimeProperty = DateTime.Now;
+            record.DateTimeProperty = DateTime.UtcNow;
             await persister.Update(record, winningSaveSession, winningContext);
             await winningSaveSession.CompleteAsync();
             winningSaveSession.Dispose();

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/NServiceBus.Persistence.ServiceFabric.Tests.csproj
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/NServiceBus.Persistence.ServiceFabric.Tests.csproj
@@ -102,7 +102,7 @@
     <Compile Include="ComponentTests\Sagas\AnotherSagaWithoutCorrelationProperty.cs" />
     <Compile Include="ComponentTests\Sagas\CombGuid.cs" />
     <Compile Include="ComponentTests\Sagas\DefaultSagaIdGenerator.cs" />
-    <Compile Include="ComponentTests\Sagas\When_multiple_workers_retrieve_same_saga_on_different_threads.cs" />
+    <Compile Include="ComponentTests\Sagas\When_retrieving_same_saga_on_different_threads.cs" />
     <Compile Include="ComponentTests\Sagas\When_worker_tries_to_complete_saga_update_by_another.cs" />
     <Compile Include="ComponentTests\Sagas\When_persisting_different_sagas_with_no_defined_unique_properties.cs" />
     <Compile Include="ComponentTests\Sagas\When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs" />
@@ -117,7 +117,7 @@
     <Compile Include="ComponentTests\Sagas\SagaWithComplexTypeEntity.cs" />
     <Compile Include="ComponentTests\Sagas\When_persisting_a_saga_with_an_escalated_DTC_transaction.cs" />
     <Compile Include="ComponentTests\Sagas\When_persisting_a_saga_with_complex_types.cs" />
-    <Compile Include="ComponentTests\Sagas\When_multiple_workers_retrieve_same_saga_on_the_same_thread.cs" />
+    <Compile Include="ComponentTests\Sagas\When_retrieving_same_saga_on_the_same_thread.cs" />
     <Compile Include="ComponentTests\Sagas\When_updating_a_saga_with_the_same_unique_property_value.cs" />
     <Compile Include="ComponentTests\SubscriptionStorageTests.cs" />
     <Compile Include="ComponentTests\PersistenceTestsConfiguration.cs" />


### PR DESCRIPTION
While working on the development saga persister in the core I detected a series of inconsistencies in the tests. This PR brings back the changes to fix the component test infrastructure in this repo since currently the tests here are the single source of truth.

- Any persister that uses a DataContractJsonSerializer cannot deal with unset / non-initialized DateTime property.
- In order to follow the core contract sessions need to be disposed when used as well as CompleteAsync needs to be called.