### PR TITLE
Sharing outbox transaction

### DIFF
--- a/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/NServiceBus.Persistence.ServiceFabric.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/NServiceBus.Persistence.ServiceFabric.AcceptanceTests.csproj
@@ -183,6 +183,7 @@
     <Compile Include="ConfigureEndpointServiceFabricPersistence.cs" />
     <Compile Include="SagaDataStorage\When_storing_saga_with_default_collection_mapping.cs" />
     <Compile Include="SagaDataStorage\When_storing_saga_with_custom_saga_attribute.cs" />
+    <Compile Include="When_trying_to_share_outbox_transaction.cs" />
     <Compile Include="Tests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="TestSuiteConstraints.cs" />

--- a/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/NServiceBus.Persistence.ServiceFabric.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/NServiceBus.Persistence.ServiceFabric.AcceptanceTests.csproj
@@ -183,7 +183,7 @@
     <Compile Include="ConfigureEndpointServiceFabricPersistence.cs" />
     <Compile Include="SagaDataStorage\When_storing_saga_with_default_collection_mapping.cs" />
     <Compile Include="SagaDataStorage\When_storing_saga_with_custom_saga_attribute.cs" />
-    <Compile Include="When_trying_to_share_outbox_transaction.cs" />
+    <Compile Include="Outbox\When_trying_to_share_outbox_transaction.cs" />
     <Compile Include="Tests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="TestSuiteConstraints.cs" />

--- a/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/Outbox/When_trying_to_share_outbox_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/Outbox/When_trying_to_share_outbox_transaction.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Persistence.ServiceFabric.AcceptanceTests
+﻿namespace NServiceBus.Persistence.ServiceFabric.AcceptanceTests.Outbox
 {
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/When_trying_to_share_outbox_transaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.AcceptanceTests/When_trying_to_share_outbox_transaction.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.Persistence.ServiceFabric.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Microsoft.ServiceFabric.Data.Collections;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_trying_to_share_outbox_transaction : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_share_it()
+        {
+            Requires.OutboxPersistence();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(session => session.SendLocal(new PlaceOrder())))
+                .Done(c => c.OrderAckReceived == 1)
+                .Run(TimeSpan.FromSeconds(20));
+
+            Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received");
+            Assert.AreEqual(context.TestRunId.ToString(), context.Value, "TestRunId should have been stored in dictionary");
+        }
+
+        class Context : ScenarioContext
+        {
+            public int OrderAckReceived { get; set; }
+            public string Value { get; set; }
+        }
+
+        public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDtcReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.EnableOutbox();
+                });
+            }
+
+            class PlaceOrderHandler : IHandleMessages<PlaceOrder>
+            {
+                Context testContext;
+
+                public PlaceOrderHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
+                {
+                    var session = context.SynchronizedStorageSession.ServiceFabricSession();
+
+                    var stateManager = session.StateManager;
+                    var handlertransaction = session.Transaction;
+
+                    var testRunId = testContext.TestRunId.ToString(); // use the test run id as dictionary name and data
+
+                    IReliableDictionary<string, string> dict;
+                    using (var customtransaction = stateManager.CreateTransaction())
+                    {
+                        dict = await stateManager.GetOrAddAsync<IReliableDictionary<string, string>>(customtransaction, testRunId)
+                            .ConfigureAwait(false);
+
+                        await customtransaction.CommitAsync().ConfigureAwait(false);
+                    }
+
+                    await dict.AddAsync(handlertransaction, testRunId, testRunId).ConfigureAwait(false);
+
+                    await context.SendLocal(new SendOrderAcknowledgement());
+                }
+            }
+
+            class SendOrderAcknowledgementHandler : IHandleMessages<SendOrderAcknowledgement>
+            {
+                Context testContext;
+
+                public SendOrderAcknowledgementHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Handle(SendOrderAcknowledgement message, IMessageHandlerContext context)
+                {
+                    var session = context.SynchronizedStorageSession.ServiceFabricSession();
+                    var stateManager = session.StateManager;
+                    var handlertransaction = session.Transaction;
+                    var testRunId = testContext.TestRunId.ToString();
+
+                    var dict = await stateManager.GetOrAddAsync<IReliableDictionary<string, string>>(handlertransaction, testRunId)
+                        .ConfigureAwait(false);
+                    var conditionalValue = await dict.TryGetValueAsync(handlertransaction, testRunId);
+
+                    testContext.Value = conditionalValue.Value;
+                    testContext.OrderAckReceived++;
+                }
+            }
+        }
+
+        public class PlaceOrder : ICommand
+        {
+        }
+
+        public class SendOrderAcknowledgement : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric.Tests/SynchronizedStorage/StorageSessionTests.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric.Tests/SynchronizedStorage/StorageSessionTests.cs
@@ -16,7 +16,7 @@
         [SetUp]
         public void SetUp()
         {
-            session = new StorageSession(stateManager, new Lazy<ITransaction>(() => stateManager.CreateTransaction()));
+            session = new StorageSession(stateManager);
         }
 
         [Test]

--- a/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj
+++ b/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj
@@ -106,6 +106,7 @@
     <Compile Include="ServiceFabricPersistenceStorageSessionExtensions.cs" />
     <Compile Include="StaticVersions.cs" />
     <Compile Include="SynchronizedStorage\IServiceFabricStorageSession.cs" />
+    <Compile Include="SynchronizedStorage\ServiceFabricTransaction.cs" />
     <Compile Include="SynchronizedStorage\SynchronizedStorage.cs" />
     <Compile Include="SynchronizedStorage\StorageSession.cs" />
     <Compile Include="SynchronizedStorage\SynchronizedStorageFeature.cs" />

--- a/src/NServiceBus.Persistence.ServiceFabric/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Outbox/OutboxStorage.cs
@@ -47,7 +47,7 @@
 
         public Task<OutboxTransaction> BeginTransaction(ContextBag context)
         {
-            return Task.FromResult<OutboxTransaction>(new ServiceFabricOutboxTransaction(reliableStateManager));
+            return Task.FromResult<OutboxTransaction>(new ServiceFabricOutboxTransaction(new ServiceFabricTransaction(reliableStateManager)));
         }
 
         public async Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
@@ -59,7 +59,7 @@
                 operations[i] = new StoredTransportOperation(t.MessageId, t.Options, t.Body, t.Headers);
             }
 
-            var tx = ((ServiceFabricOutboxTransaction) transaction).Transaction.Value;
+            var tx = ((ServiceFabricOutboxTransaction) transaction).Transaction.Transaction;
             if (!await Outbox.TryAddAsync(tx, message.MessageId, new StoredOutboxMessage(message.MessageId, operations)).ConfigureAwait(false))
             {
                 throw new Exception($"Outbox message with id '{message.MessageId}' is already present in storage.");

--- a/src/NServiceBus.Persistence.ServiceFabric/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Outbox/OutboxStorage.cs
@@ -59,7 +59,7 @@
                 operations[i] = new StoredTransportOperation(t.MessageId, t.Options, t.Body, t.Headers);
             }
 
-            var tx = ((ServiceFabricOutboxTransaction) transaction).Transaction.Transaction;
+            var tx = ((ServiceFabricOutboxTransaction) transaction).Transaction.NativeTransaction;
             if (!await Outbox.TryAddAsync(tx, message.MessageId, new StoredOutboxMessage(message.MessageId, operations)).ConfigureAwait(false))
             {
                 throw new Exception($"Outbox message with id '{message.MessageId}' is already present in storage.");

--- a/src/NServiceBus.Persistence.ServiceFabric/Outbox/ServiceFabricOutboxTransaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/Outbox/ServiceFabricOutboxTransaction.cs
@@ -1,37 +1,25 @@
 ﻿namespace NServiceBus.Persistence.ServiceFabric
 {
-    using System;
     using System.Threading.Tasks;
-    using Microsoft.ServiceFabric.Data;
     using Outbox;
 
     class ServiceFabricOutboxTransaction : OutboxTransaction
     {
-        internal IReliableStateManager StateManager { get; }
-        internal Lazy<ITransaction> Transaction { get; }
+        internal ServiceFabricTransaction Transaction { get; }
 
-        public ServiceFabricOutboxTransaction(IReliableStateManager stateManager)
+        public ServiceFabricOutboxTransaction(ServiceFabricTransaction transaction)
         {
-            StateManager = stateManager;
-            Transaction = new Lazy<ITransaction>(stateManager.CreateTransaction);
+            Transaction = transaction;
         }
 
         public void Dispose()
         {
-            if (Transaction.IsValueCreated)
-            {
-                Transaction.Value.Dispose();
-            }
+            Transaction.Dispose();
         }
 
         public Task Commit()
         {
-            if (Transaction.IsValueCreated)
-            {
-                return Transaction.Value.CommitAsync();
-            }
-
-            return TaskEx.CompletedTask;
+            return Transaction.Commit();
         }
     }
 }

--- a/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/ServiceFabricTransaction.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/ServiceFabricTransaction.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.Persistence.ServiceFabric
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.ServiceFabric.Data;
+
+    class ServiceFabricTransaction : IDisposable
+    {
+        public ServiceFabricTransaction(IReliableStateManager stateManager)
+        {
+            StateManager = stateManager;
+            actions = new List<Func<ITransaction, Task>>();
+            transaction = new Lazy<ITransaction>(StateManager.CreateTransaction);
+        }
+
+        public IReliableStateManager StateManager { get; }
+
+        public ITransaction Transaction => transaction.Value;
+
+        public void Dispose()
+        {
+            actions.Clear();
+
+            if (transaction.IsValueCreated)
+            {
+                Transaction.Dispose();
+            }
+        }
+
+        public Task Add(Func<ITransaction, Task> action)
+        {
+            actions.Add(action);
+            return TaskEx.CompletedTask;
+        }
+
+        public async Task Commit()
+        {
+            foreach (var action in actions)
+            {
+                await action(Transaction).ConfigureAwait(false);
+            }
+
+            if (transaction.IsValueCreated)
+            {
+                await Transaction.CommitAsync().ConfigureAwait(false);
+            }
+        }
+
+        // this will lead to closure allocations
+        List<Func<ITransaction, Task>> actions;
+
+        Lazy<ITransaction> transaction;
+    }
+}

--- a/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/StorageSession.cs
@@ -35,7 +35,7 @@ namespace NServiceBus.Persistence.ServiceFabric
 
         public IReliableStateManager StateManager => transaction.StateManager;
 
-        public ITransaction Transaction => transaction.Transaction;
+        public ITransaction Transaction => transaction.NativeTransaction;
 
         public Task Add(Func<ITransaction, Task> action)
         {

--- a/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/SynchronizedStorage.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Persistence.ServiceFabric
 {
-    using System;
     using System.Threading.Tasks;
     using Extensibility;
     using Microsoft.ServiceFabric.Data;
@@ -15,7 +14,7 @@ namespace NServiceBus.Persistence.ServiceFabric
         }
         public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
         {
-            var session = (CompletableSynchronizedStorageSession) new StorageSession(stateManager, new Lazy<ITransaction>(() => stateManager.CreateTransaction()));
+            var session = (CompletableSynchronizedStorageSession) new StorageSession(stateManager);
             return Task.FromResult(session);
         }
     }

--- a/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/SynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/SynchronizedStorageAdapter.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.Persistence.ServiceFabric
             var outboxTransaction = transaction as ServiceFabricOutboxTransaction;
             if (outboxTransaction != null)
             {
+                // this session will not own the transaction, the outbox part owns the transaction
                 CompletableSynchronizedStorageSession session = new StorageSession(outboxTransaction.Transaction);
                 return Task.FromResult(session);
             }

--- a/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/SynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Persistence.ServiceFabric/SynchronizedStorage/SynchronizedStorageAdapter.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Persistence.ServiceFabric
             var outboxTransaction = transaction as ServiceFabricOutboxTransaction;
             if (outboxTransaction != null)
             {
-                CompletableSynchronizedStorageSession session = new StorageSession(outboxTransaction.StateManager, outboxTransaction.Transaction);
+                CompletableSynchronizedStorageSession session = new StorageSession(outboxTransaction.Transaction);
                 return Task.FromResult(session);
             }
             return EmptyTask;


### PR DESCRIPTION
Fixes #38 

Sharing the outbox transaction with the synchronized storage can lead to InvalidOperationException because the transaction was already committed.

This PR introduces StorageSession that can wrap a SF transaction without owning it. This is the prerequisite to create a correct implementation of `SynchronizedStorageAdapter `that properly propagates transaction, without letting it being committed too early.

