### PR TITLE
Update package reference to beta5 and higher

### DIFF
--- a/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj
+++ b/src/NServiceBus.Persistence.ServiceFabric/NServiceBus.Persistence.ServiceFabric.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="Microsoft.ServiceFabric.Data" Version="[2.7.198, 3.0)" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="[5.7.198, 6.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0005, 8.0.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Because of breaking change in the core #45 we need to restrict the lower range.