### PR TITLE
Reliable concurrent queue for outbox

### DIFF
--- a/src/ServiceFabricPersistence/Outbox/OutboxPersistenceFeature.cs
+++ b/src/ServiceFabricPersistence/Outbox/OutboxPersistenceFeature.cs
@@ -74,7 +74,8 @@
                         var nextClean = now.Add(frequencyToRunDeduplicationDataCleanup);
 
                         var olderThan = now - timeToKeepDeduplicationData;
-                        await storage.CleanupMessagesOlderThan(olderThan, token).ConfigureAwait(false);
+                        await storage.CleanUpOldOutboxQueue(olderThan, token).ConfigureAwait(false);
+                        await storage.CleanUpNewOutboxQueue(olderThan, token).ConfigureAwait(false);
 
                         var delay = nextClean - now;
                         if (delay > TimeSpan.Zero)

--- a/src/ServiceFabricPersistence/Outbox/OutboxPersistenceFeature.cs
+++ b/src/ServiceFabricPersistence/Outbox/OutboxPersistenceFeature.cs
@@ -74,8 +74,8 @@
                         var nextClean = now.Add(frequencyToRunDeduplicationDataCleanup);
 
                         var olderThan = now - timeToKeepDeduplicationData;
-                        await storage.CleanUpOldOutboxQueue(olderThan, token).ConfigureAwait(false);
-                        await storage.CleanUpNewOutboxQueue(olderThan, token).ConfigureAwait(false);
+
+                        await storage.CleanUpOutboxQueue(olderThan, token).ConfigureAwait(false);
 
                         var delay = nextClean - now;
                         if (delay > TimeSpan.Zero)

--- a/src/ServiceFabricPersistence/Outbox/OutboxStateManagerExtensions.cs
+++ b/src/ServiceFabricPersistence/Outbox/OutboxStateManagerExtensions.cs
@@ -10,7 +10,8 @@ namespace NServiceBus.Persistence.ServiceFabric
         {
             storage.Outbox = await stateManager.GetOrAddAsync<IReliableDictionary<string, StoredOutboxMessage>>("outbox").ConfigureAwait(false);
 
-            storage.Cleanup = await stateManager.GetOrAddAsync<IReliableQueue<CleanupStoredOutboxCommand>>("outboxCleanup").ConfigureAwait(false);
+            storage.CleanupOld = await stateManager.GetOrAddAsync<IReliableQueue<CleanupStoredOutboxCommand>>("outboxCleanup").ConfigureAwait(false);
+            storage.Cleanup = await stateManager.GetOrAddAsync<IReliableConcurrentQueue<CleanupStoredOutboxCommand>>("outboxCleanupConcurrent").ConfigureAwait(false);
         }
     }
 }

--- a/src/ServiceFabricPersistence/Outbox/OutboxStorage.cs
+++ b/src/ServiceFabricPersistence/Outbox/OutboxStorage.cs
@@ -20,7 +20,8 @@
 
         public IReliableDictionary<string, StoredOutboxMessage> Outbox { get; set; }
 
-        public IReliableQueue<CleanupStoredOutboxCommand> Cleanup { get; set; }
+        public IReliableQueue<CleanupStoredOutboxCommand> CleanupOld { get; set; }
+        public IReliableConcurrentQueue<CleanupStoredOutboxCommand> Cleanup { get; set; }
 
         public async Task<OutboxMessage> Get(string messageId, ContextBag context)
         {
@@ -85,7 +86,7 @@
             }
         }
 
-        internal async Task CleanupMessagesOlderThan(DateTimeOffset date, CancellationToken cancellationToken)
+        internal async Task CleanUpOldOutboxQueue(DateTimeOffset olderThan, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -93,16 +94,17 @@
             {
                 var currentIndex = 0;
                 var somethingToCommit = false;
-                var cleanConditionalValue = await Cleanup.TryPeekAsync(tx, LockMode.Default, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
+                
+                var cleanConditionalValue = await CleanupOld.TryPeekAsync(tx, LockMode.Default, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
 
                 while (cleanConditionalValue.HasValue && currentIndex <= 100)
                 {
                     var cleanupCommand = cleanConditionalValue.Value;
 
-                    if (cleanupCommand.StoredAt <= date)
+                    if (cleanupCommand.StoredAt <= olderThan)
                     {
                         await Outbox.TryRemoveAsync(tx, cleanupCommand.MessageId, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
-                        await Cleanup.TryDequeueAsync(tx, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
+                        await CleanupOld.TryDequeueAsync(tx, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
                         somethingToCommit = true;
                     }
                     else
@@ -111,7 +113,50 @@
                     }
 
                     currentIndex++;
-                    cleanConditionalValue = await Cleanup.TryPeekAsync(tx, LockMode.Default, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
+                    cleanConditionalValue = await CleanupOld.TryPeekAsync(tx, LockMode.Default, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (somethingToCommit)
+                {
+                    await tx.CommitAsync().ConfigureAwait(false);
+                }
+            }
+        }
+
+        internal async Task CleanUpNewOutboxQueue(DateTimeOffset olderThan, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (var tx = reliableStateManager.CreateTransaction())
+            {
+                var currentIndex = 0;
+                var somethingToCommit = false;
+
+                var cleanConditionalValue = await Cleanup.TryDequeueAsync(tx, cancellationToken, defaultOperationTimeout).ConfigureAwait(false);
+
+                while (cleanConditionalValue.HasValue && currentIndex <= 100)
+                {
+                    var cleanupCommand = cleanConditionalValue.Value;
+
+                    if (cleanupCommand.StoredAt <= olderThan)
+                    {
+                        await Outbox.TryRemoveAsync(tx, cleanupCommand.MessageId, defaultOperationTimeout, cancellationToken).ConfigureAwait(false);
+                        somethingToCommit = true;
+                    }
+                    else
+                    {
+                        // if there's something to clean up, enqueue the message to commit the previously processed data
+                        // if there's nothing, just go outside the loop and transaction will be aborted
+                        if (somethingToCommit)
+                        {
+                            await Cleanup.EnqueueAsync(tx, cleanupCommand, cancellationToken, defaultOperationTimeout).ConfigureAwait(false);
+                        }
+
+                        break;
+                    }
+
+                    currentIndex++;
+                    cleanConditionalValue = await Cleanup.TryDequeueAsync(tx, cancellationToken, defaultOperationTimeout).ConfigureAwait(false);
                 }
 
                 if (somethingToCommit)

--- a/src/Tests/PersistenceTestsConfiguration.cs
+++ b/src/Tests/PersistenceTestsConfiguration.cs
@@ -62,9 +62,11 @@
             return Task.FromResult(0);
         }
 
-        public Task CleanupMessagesOlderThan(DateTimeOffset beforeStore)
+        public async Task CleanupMessagesOlderThan(DateTimeOffset beforeStore)
         {
-            return ((OutboxStorage) OutboxStorage).CleanupMessagesOlderThan(beforeStore, CancellationToken.None);
+            var storage = (OutboxStorage) OutboxStorage;
+            await storage.CleanUpOldOutboxQueue(beforeStore, CancellationToken.None);
+            await storage.CleanUpNewOutboxQueue(beforeStore, CancellationToken.None);
         }
     }
 }

--- a/src/Tests/PersistenceTestsConfiguration.cs
+++ b/src/Tests/PersistenceTestsConfiguration.cs
@@ -62,11 +62,10 @@
             return Task.FromResult(0);
         }
 
-        public async Task CleanupMessagesOlderThan(DateTimeOffset beforeStore)
+        public Task CleanupMessagesOlderThan(DateTimeOffset beforeStore)
         {
             var storage = (OutboxStorage) OutboxStorage;
-            await storage.CleanUpOldOutboxQueue(beforeStore, CancellationToken.None);
-            await storage.CleanUpNewOutboxQueue(beforeStore, CancellationToken.None);
+            return storage.CleanUpOutboxQueue(beforeStore, CancellationToken.None);
         }
     }
 }


### PR DESCRIPTION
This PR addresses  #61 by changing in a backward compatible manner, the queue that is used for the outbox. The queue is changed from `IReliableQueue` to `ReliableConcurrentQueue`. Because of the lack of the peek mechanism, the logic for processing messages in the concurrent queue is a bit different.

PoA:
- [x] Use the concurrent queue
- [x] Run the old and the new with `Task.WhenAll` to ensure that nothing is left in the old outbox

Notes:
- the operational lock on the old `IReliableQueue` will be short lived and only used for the query, so it should have no impact on the newly enqueued messages.