### PR TITLE
fix CommunicationListener Close and Abort

### DIFF
--- a/src/TestRunner/CommunicationListener.cs
+++ b/src/TestRunner/CommunicationListener.cs
@@ -44,15 +44,24 @@ namespace TestRunner
             });
         }
 
-        public Task CloseAsync(CancellationToken cancellationToken)
+        public async Task CloseAsync(CancellationToken cancellationToken)
         {
-            return Task.Run(() => runner.StopRun(true));
+            runner.StopRun(false);
+
+            while (true)
+            {
+                if (runner.WaitForCompletion(1))
+                {
+                    break;
+                }
+
+                await Task.Delay(3000, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public void Abort()
         {
-            // fire & forget
-            _ = CloseAsync(CancellationToken.None);
+            runner.StopRun(true);
         }
 
         public Task<string[]> Tests()


### PR DESCRIPTION
@danielmarbach it was mentioned that you might know about this.

Is there any reason we don't just call `runner.StopRun(true)` but rather fire and forget it?