### PR TITLE
Downgrade to .NET Core 3.1 SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build
@@ -48,11 +48,6 @@ jobs:
           echo $result
           
           exit 0
-      - name: Dump Env
-        shell: pwsh
-        if: ${{ always() }}
-        run: |
-          gci env:
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     name: Windows
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 3.1.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
-    runs-on: windows-2022 # Code signing requirement https://github.com/NuGet/Home/issues/7939
+    runs-on: windows-2019 # Code signing requirement https://github.com/NuGet/Home/issues/7939
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.8.2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 3.1.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
-    runs-on: windows-2019 # Code signing requirement https://github.com/NuGet/Home/issues/7939
+    runs-on: windows-2022 # Code signing requirement https://github.com/NuGet/Home/issues/7939
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0


### PR DESCRIPTION
We can't use the .NET 6 SDK, so we should go back to the previous LTS release, .NET Core 3.1.